### PR TITLE
Add go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,4 +15,14 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16.5' # The Go version to download (if necessary) and use.
+    - name: Install Protoc
+      run: |
+        cd /tmp
+        PROTOCVERSION=3.17.3
+        PROTOCZIP=$(echo "protoc-${PROTOCVERSION}-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m).zip")
+        wget https://github.com/google/protobuf/releases/download/v${PROTOCVERSION}/$PROTOCZIP
+        sudo unzip -d /usr/local/include/protoc $PROTOCZIP
+        sudo chmod a+r -R /usr/local/include/protoc
+        sudo chmod a+xr -R /usr/local/include/protoc/bin/protoc
+        sudo ln -s /usr/local/include/protoc/bin/protoc /usr/local/bin/
     - run: make all

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,8 +21,8 @@ jobs:
         PROTOCVERSION=3.17.3
         PROTOCZIP=$(echo "protoc-${PROTOCVERSION}-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m).zip")
         wget https://github.com/google/protobuf/releases/download/v${PROTOCVERSION}/$PROTOCZIP
-        sudo unzip -d /usr/local/include/protoc $PROTOCZIP
-        sudo chmod a+r -R /usr/local/include/protoc
-        sudo chmod a+xr -R /usr/local/include/protoc/bin/protoc
-        sudo ln -s /usr/local/include/protoc/bin/protoc /usr/local/bin/
+        sudo unzip -d /opt/protoc $PROTOCZIP
+        sudo chmod a+r -R /opt/protoc
+        sudo chmod a+xr /opt/protoc/bin/protoc
+        sudo ln -s /opt/protoc/bin/protoc /usr/local/bin/
     - run: make all

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,18 @@
+name: Go Build CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.16.5' # The Go version to download (if necessary) and use.
+    - run: make all

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,7 @@ jobs:
         sudo chmod a+xr /opt/protoc/bin/protoc
         sudo ln -s /opt/protoc/bin/protoc /usr/local/bin/
     - run: make all
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        path: test_results.log


### PR DESCRIPTION
This workflow build and test without building the Docker image.
It is faster and more hackable, for example to add steps about quality checking or anything else related to the source code (before being a Docker image).