### PR TITLE
Remove temporary archive in the wget RUN

### DIFF
--- a/Dockerfile.cover.local
+++ b/Dockerfile.cover.local
@@ -49,17 +49,17 @@ WORKDIR /tmp
 # Install GO $GOVERSION
 # ----------------------
 RUN wget https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz \
-&& tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
+&& tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz \
+&& rm /tmp/go$GOVERSION.linux-amd64.tar.gz
 ENV PATH $PATH:/usr/local/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN rm /tmp/go$GOVERSION.linux-amd64.tar.gz
 
 # ----------------------
 # Install Protoc $PROTOVERSION
 # ----------------------
 RUN wget https://github.com/google/protobuf/releases/download/v$PROTOVERSION/protoc-$PROTOVERSION-linux-x86_64.zip \
 && unzip -d /usr/local/protoc protoc-$PROTOVERSION-linux-x86_64.zip \
-&& ln -s /usr/local/protoc/bin/protoc /usr/local/bin
-RUN rm /tmp/protoc-$PROTOVERSION-linux-x86_64.zip
+&& ln -s /usr/local/protoc/bin/protoc /usr/local/bin \
+&& rm /tmp/protoc-$PROTOVERSION-linux-x86_64.zip
 
 ENV SHELL /bin/bash
 ENV GOPATH /go

--- a/Dockerfile.current
+++ b/Dockerfile.current
@@ -49,17 +49,17 @@ WORKDIR /tmp
 # Install GO 1.16.2
 # ----------------------
 RUN wget https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz \
-&& tar -C /usr/local -xzf go1.16.2.linux-amd64.tar.gz
+&& tar -C /usr/local -xzf go1.16.2.linux-amd64.tar.gz \
+&& rm /tmp/go1.16.2.linux-amd64.tar.gz
 ENV PATH /home/oscar/.gvm/pkgsets/go1.16.7/global/bin:/home/oscar/.gvm/gos/go1.16.7/bin:/home/oscar/.gvm/pkgsets/go1.16.7/global/overlay/bin:/home/oscar/.gvm/bin:/home/oscar/.gvm/bin:/home/oscar/.nvm/versions/node/v10.16.3/bin:/home/oscar/.pyenv/plugins/pyenv-virtualenv/shims:/home/oscar/.pyenv/shims:/home/oscar/.pyenv/bin:/home/oscar/.cargo/bin:/home/oscar/.cargo/bin:/home/oscar/.local/alt/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/oscar/.garden/bin:/home/oscar/Apps:/home/oscar/.fzf/bin:/usr/local/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN rm /tmp/go1.16.2.linux-amd64.tar.gz
 
 # ----------------------
 # Install Protoc 3.17.3
 # ----------------------
 RUN wget https://github.com/google/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-x86_64.zip \
 && unzip -d /usr/local/protoc protoc-3.17.3-linux-x86_64.zip \
-&& ln -s /usr/local/protoc/bin/protoc /usr/local/bin
-RUN rm /tmp/protoc-3.17.3-linux-x86_64.zip
+&& ln -s /usr/local/protoc/bin/protoc /usr/local/bin \
+&& rm /tmp/protoc-3.17.3-linux-x86_64.zip
 
 ENV SHELL /bin/bash
 ENV GOPATH /go

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -49,17 +49,17 @@ WORKDIR /tmp
 # Install GO $GOVERSION
 # ----------------------
 RUN wget https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz \
-&& tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
+&& tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz \
+&& rm /tmp/go$GOVERSION.linux-amd64.tar.gz
 ENV PATH $PATH:/usr/local/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN rm /tmp/go$GOVERSION.linux-amd64.tar.gz
 
 # ----------------------
 # Install Protoc $PROTOVERSION
 # ----------------------
 RUN wget https://github.com/google/protobuf/releases/download/v$PROTOVERSION/protoc-$PROTOVERSION-linux-x86_64.zip \
 && unzip -d /usr/local/protoc protoc-$PROTOVERSION-linux-x86_64.zip \
-&& ln -s /usr/local/protoc/bin/protoc /usr/local/bin
-RUN rm /tmp/protoc-$PROTOVERSION-linux-x86_64.zip
+&& ln -s /usr/local/protoc/bin/protoc /usr/local/bin \
+&& rm /tmp/protoc-$PROTOVERSION-linux-x86_64.zip
 
 ENV SHELL /bin/bash
 ENV GOPATH /go

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -49,17 +49,17 @@ WORKDIR /tmp
 # Install GO
 # ----------------------
 RUN wget https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz \
-&& tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
+&& tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz \
+&& rm /tmp/go$GOVERSION.linux-amd64.tar.gz
 ENV PATH $PATH:/usr/local/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN rm /tmp/go$GOVERSION.linux-amd64.tar.gz
 
 # ----------------------
 # Install Protoc (Version 3.17.3 by default)
 # ----------------------
 RUN wget https://github.com/google/protobuf/releases/download/v$PROTOVERSION/protoc-$PROTOVERSION-linux-x86_64.zip \
 && unzip -d /usr/local/protoc protoc-$PROTOVERSION-linux-x86_64.zip \
-&& ln -s /usr/local/protoc/bin/protoc /usr/local/bin
-RUN rm /tmp/protoc-$PROTOVERSION-linux-x86_64.zip
+&& ln -s /usr/local/protoc/bin/protoc /usr/local/bin \
+&& rm /tmp/protoc-$PROTOVERSION-linux-x86_64.zip
 
 ENV SHELL /bin/bash
 ENV GOPATH /go


### PR DESCRIPTION
Currently, as some archives are downloaded inside a RUN command and removed in a following RUN command, the archive is still present in the whole Docker Image. Removing the archive in the same RUN command avoid keeping the archive in one Docker Image Layer.
The result is a smaller Docker Image.