### PR TITLE
Add trace on error

### DIFF
--- a/lib/utils/concurrency/taskgroup_wf_test.go
+++ b/lib/utils/concurrency/taskgroup_wf_test.go
@@ -256,6 +256,7 @@ func TestChildrenWaitingGameEnoughTime(t *testing.T) {
 			fastEnough, res, xerr := overlord.WaitFor(timeout)
 			waitForRealDuration := time.Since(begin)
 			if !fastEnough {
+				t.Logf("WaitFor failed: %s", xerr)
 				if childrenStartDuration > 5*time.Millisecond { // however, it grows with gcpressure
 					t.Logf("Launching children took %v", childrenStartDuration)
 				}


### PR DESCRIPTION
Log the error when WaitFor is not successful.