### PR TITLE
Propagate context.Context

### DIFF
--- a/build/rules/ruleguard.rules.hardened.go
+++ b/build/rules/ruleguard.rules.hardened.go
@@ -22,6 +22,37 @@ package gorules
 import "github.com/quasilyte/go-ruleguard/dsl"
 
 // This is a collection of rules for ruleguard: https://github.com/quasilyte/go-ruleguard
+func repairs1(m dsl.Matcher) {
+	m.Import("github.com/CS-SI/SafeScale/v21/lib/utils/fail")
+
+	m.Match("if xerr != nil { return $b }").
+		Where((m["b"].Type.Is("error") || m["b"].Type.Is("fail.Error")) && !m["b"].Text.Matches(".*xerr.*")).
+		Report("returning the wrong error?")
+}
+
+func repairs1b(m dsl.Matcher) {
+	m.Import("github.com/CS-SI/SafeScale/v21/lib/utils/fail")
+
+	m.Match("if err != nil { return $b }").
+		Where((m["b"].Type.Is("error") || m["b"].Type.Is("fail.Error")) && !m["b"].Text.Matches(".*err.*")).
+		Report("returning the wrong error?")
+}
+
+func repairs2(m dsl.Matcher) {
+	m.Import("github.com/CS-SI/SafeScale/v21/lib/utils/fail")
+
+	m.Match("if xerr != nil { return nil, $b }").
+		Where((m["b"].Type.Is("error") || m["b"].Type.Is("fail.Error")) && !m["b"].Text.Matches(".*xerr.*")).
+		Report("returning the wrong error?")
+}
+
+func repairs2b(m dsl.Matcher) {
+	m.Import("github.com/CS-SI/SafeScale/v21/lib/utils/fail")
+
+	m.Match("if err != nil { return nil, $b }").
+		Where((m["b"].Type.Is("error") || m["b"].Type.Is("fail.Error")) && !m["b"].Text.Matches(".*err.*")).
+		Report("returning the wrong error?")
+}
 
 // Remove extra conversions: mdempsky/unconvert
 func unconvert(m dsl.Matcher) {

--- a/build/rules/ruleguard.rules.hardened.go
+++ b/build/rules/ruleguard.rules.hardened.go
@@ -23,7 +23,7 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 
 // This is a collection of rules for ruleguard: https://github.com/quasilyte/go-ruleguard
 func repairs1(m dsl.Matcher) {
-	m.Import("github.com/CS-SI/SafeScale/v21/lib/utils/fail")
+	m.Import("github.com/CS-SI/SafeScale/v22/lib/utils/fail")
 
 	m.Match("if xerr != nil { return $b }").
 		Where((m["b"].Type.Is("error") || m["b"].Type.Is("fail.Error")) && !m["b"].Text.Matches(".*xerr.*")).
@@ -31,7 +31,7 @@ func repairs1(m dsl.Matcher) {
 }
 
 func repairs1b(m dsl.Matcher) {
-	m.Import("github.com/CS-SI/SafeScale/v21/lib/utils/fail")
+	m.Import("github.com/CS-SI/SafeScale/v22/lib/utils/fail")
 
 	m.Match("if err != nil { return $b }").
 		Where((m["b"].Type.Is("error") || m["b"].Type.Is("fail.Error")) && !m["b"].Text.Matches(".*err.*")).
@@ -39,7 +39,7 @@ func repairs1b(m dsl.Matcher) {
 }
 
 func repairs2(m dsl.Matcher) {
-	m.Import("github.com/CS-SI/SafeScale/v21/lib/utils/fail")
+	m.Import("github.com/CS-SI/SafeScale/v22/lib/utils/fail")
 
 	m.Match("if xerr != nil { return nil, $b }").
 		Where((m["b"].Type.Is("error") || m["b"].Type.Is("fail.Error")) && !m["b"].Text.Matches(".*xerr.*")).
@@ -47,7 +47,7 @@ func repairs2(m dsl.Matcher) {
 }
 
 func repairs2b(m dsl.Matcher) {
-	m.Import("github.com/CS-SI/SafeScale/v21/lib/utils/fail")
+	m.Import("github.com/CS-SI/SafeScale/v22/lib/utils/fail")
 
 	m.Match("if err != nil { return nil, $b }").
 		Where((m["b"].Type.Is("error") || m["b"].Type.Is("fail.Error")) && !m["b"].Text.Matches(".*err.*")).

--- a/cli/safescale/commands/cluster.go
+++ b/cli/safescale/commands/cluster.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	appwide "github.com/CS-SI/SafeScale/v22/lib/utils/app"
+	"github.com/CS-SI/SafeScale/v22/lib/utils/debug"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
@@ -103,11 +104,13 @@ var clusterListCommand = cli.Command{
 			// c, _ := value.(api.Cluster)
 			converted, err := convertToMap(value)
 			if err != nil {
+				debug.IgnoreError(err)
 				return clitools.FailureResponse(clitools.ExitOnErrorWithMessage(exitcode.Run, fmt.Sprintf("failed to extract data about cluster '%s'", clusterName)))
 			}
 
 			fconfig, err := formatClusterConfig(converted, false)
 			if err != nil {
+				debug.IgnoreError(err)
 				return clitools.FailureResponse(clitools.ExitOnErrorWithMessage(exitcode.Run, fmt.Sprintf("failed to extract data about cluster '%s'", clusterName)))
 			}
 			formatted = append(formatted, fconfig)

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/ovh/go-ovh v1.1.0
 	github.com/pelletier/go-toml/v2 v2.0.0-beta.8
 	github.com/pkg/sftp v1.13.4
+	github.com/quasilyte/go-ruleguard/dsl v0.3.17 // indirect
 	github.com/sanity-io/litter v1.5.4
 	github.com/sethvargo/go-password v0.2.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -681,6 +681,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/quasilyte/go-ruleguard/dsl v0.3.17 h1:L5xf3nifnRIdYe9vyMuY2sDnZHIgQol/fDq74FQz7ZY=
+github.com/quasilyte/go-ruleguard/dsl v0.3.17/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/lib/server/handlers/share.go
+++ b/lib/server/handlers/share.go
@@ -174,7 +174,7 @@ func (handler *shareHandler) List() (shares map[string]map[string]*propertiesv1.
 			return nil, xerr
 		}
 
-		xerr = host.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+		xerr = host.Inspect(task.Context(), func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 			return props.Inspect(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 				hostSharesV1, ok := clonable.(*propertiesv1.HostShares)
 				if !ok {

--- a/lib/server/handlers/ssh.go
+++ b/lib/server/handlers/ssh.go
@@ -142,7 +142,7 @@ func (handler *sshHandler) GetConfig(hostParam stacks.HostParameter) (sshConfig 
 	}
 
 	if isSingle || isGateway {
-		xerr = host.Inspect(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+		xerr = host.Inspect(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 			ahc, ok := clonable.(*abstract.HostCore)
 			if !ok {
 				return fail.InconsistentError("")
@@ -157,7 +157,7 @@ func (handler *sshHandler) GetConfig(hostParam stacks.HostParameter) (sshConfig 
 		}
 	} else {
 		var subnetInstance resources.Subnet
-		xerr = host.Inspect(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+		xerr = host.Inspect(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 			ahc, ok := clonable.(*abstract.HostCore)
 			if !ok {
 				return fail.InconsistentError("")
@@ -221,7 +221,7 @@ func (handler *sshHandler) GetConfig(hostParam stacks.HostParameter) (sshConfig 
 				return nil, xerr
 			}
 		} else {
-			xerr = gw.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+			xerr = gw.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 				if gwahc, ok = clonable.(*abstract.HostCore); !ok {
 					return fail.InconsistentError("'*abstract.HostCore' expected, '%s' provided", reflect.TypeOf(clonable).String())
 				}
@@ -265,7 +265,7 @@ func (handler *sshHandler) GetConfig(hostParam stacks.HostParameter) (sshConfig 
 				return nil, xerr
 			}
 		} else {
-			xerr = gw.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+			xerr = gw.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 				gwahc, ok = clonable.(*abstract.HostCore)
 				if !ok {
 					return fail.InconsistentError("'*abstract.HostFull' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/handlers/ssh.go
+++ b/lib/server/handlers/ssh.go
@@ -131,7 +131,7 @@ func (handler *sshHandler) GetConfig(hostParam stacks.HostParameter) (sshConfig 
 		User:      user,
 	}
 
-	isSingle, xerr := host.IsSingle()
+	isSingle, xerr := host.IsSingle(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}

--- a/lib/server/handlers/ssh.go
+++ b/lib/server/handlers/ssh.go
@@ -136,7 +136,7 @@ func (handler *sshHandler) GetConfig(hostParam stacks.HostParameter) (sshConfig 
 		return nil, xerr
 	}
 
-	isGateway, xerr := host.IsGateway()
+	isGateway, xerr := host.IsGateway(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -196,7 +196,7 @@ func (handler *sshHandler) GetConfig(hostParam stacks.HostParameter) (sshConfig 
 			return nil, fail.NotFoundError("failed to find default Subnet of Host")
 		}
 		if isGateway {
-			hs, err := host.GetState()
+			hs, err := host.GetState(ctx)
 			if err != nil {
 				return nil, fail.Wrap(err, "cannot retrieve host properties")
 			}

--- a/lib/server/handlers/tenant.go
+++ b/lib/server/handlers/tenant.go
@@ -396,7 +396,7 @@ func (handler *tenantHandler) Scan(tenantName string, isDryRun bool, templateNam
 		}
 	}()
 
-	xerr = subnet.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = subnet.Inspect(context.Background(), func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/handlers/volume.go
+++ b/lib/server/handlers/volume.go
@@ -129,7 +129,7 @@ func (handler *volumeHandler) Delete(ref string) (ferr fail.Error) {
 		}
 	}
 
-	xerr = volumeInstance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = volumeInstance.Inspect(task.Context(), func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(volumeproperty.AttachedV1, func(clonable data.Clonable) fail.Error {
 			volumeAttachmentsV1, ok := clonable.(*propertiesv1.VolumeAttachments)
 			if !ok {

--- a/lib/server/iaas/objectstorage/bucket.go
+++ b/lib/server/iaas/objectstorage/bucket.go
@@ -17,6 +17,7 @@
 package objectstorage
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -102,7 +103,7 @@ func (instance bucket) CreateObject(objectName string) (_ Object, ferr fail.Erro
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "(%s)", objectName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "(%s)", objectName).Entering().Exiting()
 
 	o, err := newObject(&instance, objectName)
 	if err != nil {
@@ -118,7 +119,7 @@ func (instance bucket) InspectObject(objectName string) (_ Object, ferr fail.Err
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "(%s)", objectName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "(%s)", objectName).Entering().Exiting()
 
 	o, err := newObject(&instance, objectName)
 	if err != nil {
@@ -175,7 +176,7 @@ func (instance bucket) ListObjects(path, prefix string) (_ []string, ferr fail.E
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "(%s, %s)", path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "(%s, %s)", path, prefix).Entering().Exiting()
 
 	var list []string
 
@@ -211,7 +212,7 @@ func (instance bucket) Browse(path, prefix string, callback func(Object) fail.Er
 		return fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "('%s', '%s')", path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "('%s', '%s')", path, prefix).Entering().Exiting()
 
 	fullPath := buildFullPath(path, prefix)
 
@@ -242,7 +243,7 @@ func (instance bucket) Clear(path, prefix string) (ferr fail.Error) {
 		return fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "('%s', '%s')", path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "('%s', '%s')", path, prefix).Entering().Exiting()
 
 	fullPath := buildFullPath(path, prefix)
 
@@ -278,7 +279,7 @@ func (instance bucket) DeleteObject(objectName string) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeEmptyStringError("objectName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "('%s')", objectName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "('%s')", objectName).Entering().Exiting()
 
 	o, err := newObject(&instance, objectName)
 	if err != nil {
@@ -294,7 +295,7 @@ func (instance bucket) ReadObject(objectName string, target io.Writer, from int6
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "('%s', %d, %d)", objectName, from, to).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "('%s', %d, %d)", objectName, from, to).Entering().Exiting()
 
 	o, err := newObject(&instance, objectName)
 	if err != nil {
@@ -314,7 +315,7 @@ func (instance bucket) WriteObject(objectName string, source io.Reader, sourceSi
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "('%s', %d)", objectName, sourceSize).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "('%s', %d)", objectName, sourceSize).Entering().Exiting()
 
 	o, err := newObject(&instance, objectName)
 	if err != nil {
@@ -346,7 +347,7 @@ func (instance bucket) WriteMultiPartObject(
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "('%s', <source>, %d, %d, <metadata>)", objectName, sourceSize, chunkSize).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "('%s', <source>, %d, %d, <metadata>)", objectName, sourceSize, chunkSize).Entering().Exiting()
 
 	o, err := newObject(&instance, objectName)
 	if err != nil {
@@ -380,7 +381,7 @@ func (instance bucket) GetCount(path, prefix string) (_ int64, ferr fail.Error) 
 		return 0, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "('%s', '%s')", path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "('%s', '%s')", path, prefix).Entering().Exiting()
 
 	var count int64
 	fullPath := buildFullPath(path, prefix)
@@ -414,7 +415,7 @@ func (instance bucket) GetSize(path, prefix string) (_ int64, _ string, ferr fai
 		return 0, "", fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "('%s', '%s')", path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "('%s', '%s')", path, prefix).Entering().Exiting()
 
 	fullPath := buildFullPath(path, prefix)
 

--- a/lib/server/iaas/objectstorage/location.go
+++ b/lib/server/iaas/objectstorage/location.go
@@ -19,6 +19,7 @@ package objectstorage
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -273,7 +274,7 @@ func (instance location) ListBuckets(prefix string) (_ []string, ferr fail.Error
 		return []string{}, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s')", prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s')", prefix).Entering().Exiting()
 
 	var list []string
 
@@ -310,7 +311,7 @@ func (instance location) FindBucket(bucketName string) (_ bool, ferr fail.Error)
 		return false, fail.InvalidParameterCannotBeEmptyStringError("bucketName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "(%s)", bucketName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "(%s)", bucketName).Entering().Exiting()
 
 	found := false
 
@@ -349,7 +350,7 @@ func (instance location) InspectBucket(bucketName string) (_ abstract.ObjectStor
 		return abstract.ObjectStorageBucket{}, fail.InvalidParameterCannotBeEmptyStringError("bucketName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "(%s)", bucketName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "(%s)", bucketName).Entering().Exiting()
 
 	b, err := instance.GetBucket(bucketName)
 	if err != nil {
@@ -408,7 +409,7 @@ func (instance location) CreateBucket(bucketName string) (aosb abstract.ObjectSt
 		return aosb, fail.InvalidParameterCannotBeEmptyStringError("bucketName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s')", bucketName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s')", bucketName).Entering().Exiting()
 
 	c, err := instance.stowLocation.CreateContainer(bucketName)
 	if err != nil {
@@ -431,7 +432,7 @@ func (instance location) DeleteBucket(bucketName string) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeEmptyStringError("bucketName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s')", bucketName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s')", bucketName).Entering().Exiting()
 
 	err := instance.stowLocation.RemoveContainer(bucketName)
 	if err != nil {
@@ -458,7 +459,7 @@ func (instance location) InspectObject(bucketName string, objectName string) (ao
 		return aosi, fail.InvalidParameterCannotBeEmptyStringError("objectName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
 
 	b, err := instance.GetBucket(bucketName)
 	if err != nil {
@@ -496,7 +497,7 @@ func (instance location) DeleteObject(bucketName, objectName string) (ferr fail.
 		return fail.InvalidParameterCannotBeEmptyStringError("objectName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
 
 	b, err := instance.GetBucket(bucketName)
 	if err != nil {
@@ -515,7 +516,7 @@ func (instance location) ListObjects(bucketName string, path, prefix string) (_ 
 		return []string{}, fail.InvalidParameterCannotBeEmptyStringError("bucketName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', '%s')", bucketName, path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', '%s')", bucketName, path, prefix).Entering().Exiting()
 
 	b, err := instance.GetBucket(bucketName)
 	if err != nil {
@@ -534,7 +535,7 @@ func (instance location) BrowseBucket(bucketName string, path, prefix string, ca
 		return fail.InvalidParameterCannotBeEmptyStringError("bucketName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', '%s')", bucketName, path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', '%s')", bucketName, path, prefix).Entering().Exiting()
 
 	b, err := instance.GetBucket(bucketName)
 	if err != nil {
@@ -557,7 +558,7 @@ func (instance location) DownloadBucket(bucketName, decryptionKey string) (_ []b
 	path := ""
 	prefix := ""
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', '%s')", bucketName, path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', '%s')", bucketName, path, prefix).Entering().Exiting()
 
 	zippedBucket, err := os.CreateTemp("", "bucketcontent.*.zip")
 	if err != nil {
@@ -638,7 +639,7 @@ func (instance location) ClearBucket(bucketName string, path, prefix string) (fe
 		return fail.InvalidParameterCannotBeEmptyStringError("bucketName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', '%s')", bucketName, path, prefix).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', '%s')", bucketName, path, prefix).Entering().Exiting()
 
 	b, err := instance.GetBucket(bucketName)
 	if err != nil {
@@ -659,7 +660,7 @@ func (instance location) ItemEtag(bucketName, objectName string) (_ string, ferr
 		return "", fail.InvalidParameterCannotBeEmptyStringError("objectName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
 
 	b, err := instance.GetBucket(bucketName)
 	if err != nil {
@@ -687,7 +688,7 @@ func (instance location) HasObject(bucketName, objectName string) (_ bool, ferr 
 		return false, fail.InvalidParameterCannotBeEmptyStringError("objectName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
 
 	b, xerr := instance.GetBucket(bucketName)
 	if xerr != nil {
@@ -721,7 +722,7 @@ func (instance location) ReadObject(bucketName, objectName string, writer io.Wri
 		return fail.InvalidParameterCannotBeEmptyStringError("objectName")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s')", bucketName, objectName).Entering().Exiting()
 
 	has, err := instance.HasObject(bucketName, objectName)
 	if err != nil {
@@ -771,7 +772,7 @@ func (instance location) WriteObject(
 		return aosi, fail.InvalidParameterCannotBeNilError("source")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', %d)", bucketName, objectName, size).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', %d)", bucketName, objectName, size).Entering().Exiting()
 
 	b, err := instance.GetBucket(bucketName)
 	if err != nil {
@@ -815,7 +816,7 @@ func (instance location) WriteMultiPartObject(
 		return aosi, fail.InvalidParameterCannotBeEmptyStringError("objectName")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', %d, %d)", bucketName, objectName, sourceSize, chunkSize).Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage.stowLocation"), "('%s', '%s', %d, %d)", bucketName, objectName, sourceSize, chunkSize).Entering()
 	defer tracer.Exiting()
 
 	b, err := instance.GetBucket(bucketName)

--- a/lib/server/iaas/objectstorage/object.go
+++ b/lib/server/iaas/objectstorage/object.go
@@ -18,6 +18,7 @@ package objectstorage
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strconv"
@@ -130,7 +131,7 @@ func (instance *object) Reload() fail.Error {
 		return fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
 
 	item, err := instance.bucket.stowContainer.Item(instance.name)
 	if err != nil {
@@ -170,7 +171,7 @@ func (instance *object) Read(target io.Writer, from, to int64) (ferr fail.Error)
 		return fail.InvalidParameterError("from", "cannot be greater than 'to'")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "(%d, %d)", from, to).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "(%d, %d)", from, to).Entering().Exiting()
 
 	var seekTo int64
 	var length int64
@@ -257,7 +258,7 @@ func (instance *object) Write(source io.Reader, sourceSize int64) fail.Error {
 		return fail.InvalidInstanceContentError("instance.bucket", "cannot be nil")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "(%d)", sourceSize).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "(%d)", sourceSize).Entering().Exiting()
 
 	item, err := instance.bucket.stowContainer.Put(instance.name, source, sourceSize, instance.metadata)
 	if err != nil {
@@ -276,7 +277,7 @@ func (instance *object) WriteMultiPart(source io.Reader, sourceSize int64, chunk
 		return nil
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "(%d, %d)", sourceSize, chunkSize).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "(%d, %d)", sourceSize, chunkSize).Entering().Exiting()
 
 	metadataCopy := instance.metadata.Clone()
 
@@ -329,7 +330,7 @@ func (instance *object) Delete() fail.Error {
 		return fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
 
 	err := instance.bucket.stowContainer.RemoveItem(instance.name)
 	if err != nil {
@@ -345,7 +346,7 @@ func (instance *object) ForceAddMetadata(newMetadata abstract.ObjectStorageItemM
 		return fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
 
 	for k, v := range newMetadata {
 		instance.metadata[k] = v
@@ -359,7 +360,7 @@ func (instance *object) AddMetadata(newMetadata abstract.ObjectStorageItemMetada
 		return fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
 
 	for k, v := range newMetadata {
 		_, found := instance.metadata[k]
@@ -376,7 +377,7 @@ func (instance *object) ReplaceMetadata(newMetadata abstract.ObjectStorageItemMe
 		return fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("objectstorage"), "").Entering().Exiting()
 
 	instance.metadata = newMetadata
 	return nil

--- a/lib/server/iaas/service.go
+++ b/lib/server/iaas/service.go
@@ -17,6 +17,7 @@
 package iaas
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -483,7 +484,7 @@ func (instance service) ListTemplatesBySizing(
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true, "").Entering()
+	tracer := debug.NewTracer(context.Background(), true, "").Entering()
 	defer tracer.Exiting()
 
 	allTpls, rerr := instance.ListTemplates(false)

--- a/lib/server/iaas/stacks/aws/compute.go
+++ b/lib/server/iaas/stacks/aws/compute.go
@@ -17,6 +17,7 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -51,7 +52,7 @@ func (s stack) CreateKeyPair(name string) (_ *abstract.KeyPair, ferr fail.Error)
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "('%s')", name).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "('%s')", name).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	keypair, xerr := abstract.NewKeyPair(name)
@@ -74,7 +75,7 @@ func (s stack) ImportKeyPair(keypair *abstract.KeyPair) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeNilError("keypair")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%v)", keypair).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%v)", keypair).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	return s.rpcImportKeyPair(aws.String(keypair.Name), []byte(keypair.PublicKey))
@@ -90,7 +91,7 @@ func (s stack) InspectKeyPair(id string) (_ *abstract.KeyPair, ferr fail.Error) 
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).
 		WithStopwatch().
 		Entering().
 		Exiting()
@@ -119,7 +120,7 @@ func (s stack) ListKeyPairs() (_ []*abstract.KeyPair, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).
 		WithStopwatch().
 		Entering().
 		Exiting()
@@ -142,7 +143,7 @@ func (s stack) DeleteKeyPair(id string) (ferr fail.Error) {
 		return fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	return s.rpcDeleteKeyPair(aws.String(id))
@@ -155,7 +156,7 @@ func (s stack) ListAvailabilityZones() (_ map[string]bool, ferr fail.Error) {
 		return emptyMap, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	resp, xerr := s.rpcDescribeAvailabilityZones(nil)
@@ -182,7 +183,7 @@ func (s stack) ListRegions() (_ []string, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	resp, xerr := s.rpcDescribeRegions(nil)
@@ -209,7 +210,7 @@ func (s stack) InspectImage(id string) (_ *abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	resp, xerr := s.rpcDescribeImageByID(aws.String(id))
@@ -229,7 +230,7 @@ func (s stack) InspectTemplate(id string) (template *abstract.HostTemplate, ferr
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	resp, xerr := s.rpcDescribeInstanceTypeByID(aws.String(id))
@@ -321,7 +322,7 @@ func (s stack) ListImages(all bool) (_ []*abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	resp, xerr := s.rpcDescribeImages(nil)
@@ -361,7 +362,7 @@ func (s stack) ListTemplates(all bool) (templates []*abstract.HostTemplate, ferr
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	var resp []*ec2.InstanceTypeInfo
@@ -443,7 +444,7 @@ func (s stack) WaitHostReady(hostParam stacks.HostParameter, timeout time.Durati
 		return nil, xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s, %v)", hostRef, timeout).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s, %v)", hostRef, timeout).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	retryErr := retry.WhileUnsuccessful(
@@ -500,7 +501,7 @@ func (s stack) CreateHost(request abstract.HostRequest) (ahf *abstract.HostFull,
 		return nil, nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%v)", request).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%v)", request).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	resourceName := request.ResourceName
@@ -816,7 +817,7 @@ func (s stack) InspectHost(hostParam stacks.HostParameter) (ahf *abstract.HostFu
 		return nil, xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).WithStopwatch().Entering().Exiting()
 
 	var resp *ec2.Instance
 	if ahf.Core.ID != "" {
@@ -961,7 +962,7 @@ func (s stack) InspectHostByName(name string) (_ *abstract.HostFull, ferr fail.E
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "('%s')", name).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "('%s')", name).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	resp, xerr := s.rpcDescribeInstanceByName(aws.String(name))
@@ -993,7 +994,7 @@ func (s stack) ListHosts(details bool) (hosts abstract.HostList, ferr fail.Error
 		return nullList, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(details=%v)", details).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(details=%v)", details).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	resp, xerr := s.rpcDescribeInstances(nil)
@@ -1042,7 +1043,7 @@ func (s stack) DeleteHost(hostParam stacks.HostParameter) (ferr fail.Error) {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	vm, xerr := s.rpcDescribeInstanceByID(aws.String(ahf.GetID()))
@@ -1165,7 +1166,7 @@ func (s stack) StopHost(hostParam stacks.HostParameter, gracefully bool) (ferr f
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	timings, xerr := s.Timings()
@@ -1221,7 +1222,7 @@ func (s stack) StartHost(hostParam stacks.HostParameter) (ferr fail.Error) {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	timings, xerr := s.Timings()
@@ -1281,7 +1282,7 @@ func (s stack) RebootHost(hostParam stacks.HostParameter) (ferr fail.Error) {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitTraceError(&ferr)
 
 	if xerr = s.rpcRebootInstances([]*string{aws.String(ahf.Core.ID)}); xerr != nil {

--- a/lib/server/iaas/stacks/aws/network.go
+++ b/lib/server/iaas/stacks/aws/network.go
@@ -17,6 +17,7 @@
 package aws
 
 import (
+	"context"
 	"net"
 	"reflect"
 
@@ -64,7 +65,7 @@ func (s stack) CreateNetwork(req abstract.NetworkRequest) (res *abstract.Network
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%v)", req).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%v)", req).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -187,7 +188,7 @@ func (s stack) InspectNetwork(id string) (_ *abstract.Network, ferr fail.Error) 
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	resp, xerr := s.rpcDescribeVpcByID(aws.String(id))
 	if xerr != nil {
@@ -230,7 +231,7 @@ func (s stack) InspectNetworkByName(name string) (_ *abstract.Network, ferr fail
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "('%s')", name).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "('%s')", name).WithStopwatch().Entering().Exiting()
 
 	resp, xerr := s.rpcDescribeVpcByName(aws.String(name))
 	if xerr != nil {
@@ -252,7 +253,7 @@ func (s stack) ListNetworks() (_ []*abstract.Network, ferr fail.Error) {
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network")).WithStopwatch().Entering().Exiting()
 
 	resp, xerr := s.rpcDescribeVpcs(nil)
 	if xerr != nil {
@@ -284,7 +285,7 @@ func (s stack) DeleteNetwork(id string) (ferr fail.Error) {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	var xerr fail.Error
 	if _, xerr = s.InspectNetwork(id); xerr != nil {
@@ -389,7 +390,7 @@ func (s stack) CreateSubnet(req abstract.SubnetRequest) (res *abstract.Subnet, f
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%v)", req).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%v)", req).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -475,7 +476,7 @@ func (s stack) InspectSubnet(id string) (_ *abstract.Subnet, ferr fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	resp, xerr := s.rpcDescribeSubnetByID(aws.String(id))
 	if xerr != nil {
@@ -512,7 +513,7 @@ func (s stack) InspectSubnetByName(networkRef, subnetName string) (_ *abstract.S
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "('%s', '%s')", networkRef, subnetName).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "('%s', '%s')", networkRef, subnetName).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -563,7 +564,7 @@ func (s stack) ListSubnets(networkRef string) (list []*abstract.Subnet, ferr fai
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network")).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -629,7 +630,7 @@ func (s stack) initEC2DescribeSubnetsInput(networkRef string) (*ec2.DescribeSubn
 
 // listSubnetIDs ...
 func (s stack) listSubnetIDs(networkRef string) (list []string, ferr fail.Error) { // nolint
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network")).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -670,7 +671,7 @@ func (s stack) DeleteSubnet(id string) (ferr fail.Error) {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	// Disassociate route tables from subnet
 	tables, xerr := s.rpcDescribeRouteTables(aws.String("association.subnet-id"), []*string{aws.String(id)})

--- a/lib/server/iaas/stacks/aws/rpc.go
+++ b/lib/server/iaas/stacks/aws/rpc.go
@@ -1899,11 +1899,11 @@ func (s stack) rpcTerminateInstance(instance *ec2.Instance) fail.Error {
 
 			state, xerr := toHostState(resp[0].State)
 			if xerr != nil {
-				return fail.NewError("failed to convert instance state")
+				return fail.NewErrorWithCause(xerr, "failed to convert instance state")
 			}
 
 			if state != hoststate.Terminated {
-				return fail.NewError(innerXErr, "not in terminated state (current state: %s)", state.String())
+				return fail.NewError("not in terminated state (current state: %s)", state.String())
 			}
 
 			return nil

--- a/lib/server/iaas/stacks/aws/securitygroup.go
+++ b/lib/server/iaas/stacks/aws/securitygroup.go
@@ -17,6 +17,8 @@
 package aws
 
 import (
+	"context"
+
 	"github.com/CS-SI/SafeScale/v22/lib/utils/valid"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -37,7 +39,7 @@ func (s stack) ListSecurityGroups(networkID string) ([]*abstract.SecurityGroup, 
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.securitygroup") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.securitygroup") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcDescribeSecurityGroups(aws.String(networkID), nil)
@@ -66,7 +68,7 @@ func (s stack) CreateSecurityGroup(networkRef, name, description string, rules a
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	network, xerr := s.InspectNetwork(networkRef)
@@ -224,7 +226,7 @@ func (s stack) DeleteSecurityGroup(asg *abstract.SecurityGroup) (ferr fail.Error
 		}
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcDeleteSecurityGroup(aws.String(asg.ID))
@@ -240,7 +242,7 @@ func (s stack) InspectSecurityGroup(sgParam stacks.SecurityGroupParameter) (*abs
 		return nil, xerr
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	if asg.ID != "" {
@@ -379,7 +381,7 @@ func (s stack) ClearSecurityGroup(sgParam stacks.SecurityGroupParameter) (*abstr
 		}
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.aws"), "(%s)", asg.ID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.aws"), "(%s)", asg.ID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcDescribeSecurityGroupByID(aws.String(asg.ID))
@@ -419,7 +421,7 @@ func (s stack) AddRuleToSecurityGroup(sgParam stacks.SecurityGroupParameter, rul
 		return nil, fail.InvalidParameterCannotBeNilError("rule")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	ingressPermissions, egressPermissions, xerr := s.fromAbstractSecurityGroupRules(*asg, abstract.SecurityGroupRules{rule})
@@ -470,7 +472,7 @@ func (s stack) DeleteRuleFromSecurityGroup(sgParam stacks.SecurityGroupParameter
 		return nil, fail.InvalidParameterCannotBeNilError("rule")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s, '%s')", asg.ID, rule.Description).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s, '%s')", asg.ID, rule.Description).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	ingressPermissions, egressPermissions, xerr := s.fromAbstractSecurityGroupRules(*asg, abstract.SecurityGroupRules{rule})

--- a/lib/server/iaas/stacks/aws/volume.go
+++ b/lib/server/iaas/stacks/aws/volume.go
@@ -17,6 +17,7 @@
 package aws
 
 import (
+	"context"
 	"sort"
 	"strings"
 
@@ -41,7 +42,7 @@ func (s stack) CreateVolume(request abstract.VolumeRequest) (_ *abstract.Volume,
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.volume"), "(%v)", request).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.volume"), "(%v)", request).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	volumeType, minSize := fromAbstractVolumeSpeed(request.Speed)
@@ -82,7 +83,7 @@ func (s stack) InspectVolume(ref string) (_ *abstract.Volume, ferr fail.Error) {
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("ref")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", ref).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", ref).WithStopwatch().Entering().Exiting()
 	// VPL: caller must log; sometimes InspectVolume() returned error is to be considered as an information, not a real error
 	// defer fail.OnExitLogError(&xerr)
 
@@ -190,7 +191,7 @@ func (s stack) ListVolumes() (_ []*abstract.Volume, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	var resp *ec2.DescribeVolumesOutput
@@ -240,7 +241,7 @@ func (s stack) DeleteVolume(id string) (ferr fail.Error) {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	query := ec2.DeleteVolumeInput{
@@ -261,7 +262,7 @@ func (s stack) CreateVolumeAttachment(request abstract.VolumeAttachmentRequest) 
 		return "", fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%v)", request).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%v)", request).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	availableDevices := initAvailableDevices()
@@ -365,7 +366,7 @@ func (s stack) InspectVolumeAttachment(serverID, id string) (_ *abstract.VolumeA
 		return nilA, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 	// VPL: caller MUST log; sometimes, InspectVolumeAttachment returned error may be considered as an information of non-existence, not a real error
 	// defer fail.OnExitLogError(&xerr)
 
@@ -406,7 +407,7 @@ func (s stack) ListVolumeAttachments(serverID string) (_ []*abstract.VolumeAttac
 		return nil, fail.InvalidParameterError("serverID", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", serverID).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s)", serverID).WithStopwatch().Entering().Exiting()
 
 	query := ec2.DescribeVolumesInput{
 		Filters: []*ec2.Filter{
@@ -458,7 +459,7 @@ func (s stack) DeleteVolumeAttachment(serverID, id string) (ferr fail.Error) {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s, %s)", serverID, id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.aws") || tracing.ShouldTrace("stacks.network"), "(%s, %s)", serverID, id).WithStopwatch().Entering().Exiting()
 
 	query := ec2.DetachVolumeInput{
 		InstanceId: aws.String(serverID),

--- a/lib/server/iaas/stacks/gcp/compute.go
+++ b/lib/server/iaas/stacks/gcp/compute.go
@@ -17,6 +17,7 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -48,7 +49,7 @@ func (s stack) ListImages(bool) (out []*abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	resp, xerr := s.rpcListImages()
@@ -81,7 +82,7 @@ func (s stack) InspectImage(id string) (_ *abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	resp, xerr := s.rpcGetImageByID(id)
@@ -99,7 +100,7 @@ func (s stack) ListTemplates(bool) (templates []*abstract.HostTemplate, ferr fai
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	resp, xerr := s.rpcListMachineTypes()
@@ -135,7 +136,7 @@ func (s stack) InspectTemplate(id string) (_ *abstract.HostTemplate, ferr fail.E
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	resp, xerr := s.rpcGetMachineType(id)
@@ -157,7 +158,7 @@ func (s stack) CreateKeyPair(name string) (_ *abstract.KeyPair, ferr fail.Error)
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 
 	return abstract.NewKeyPair(name)
@@ -184,7 +185,7 @@ func (s stack) CreateHost(request abstract.HostRequest) (ahf *abstract.HostFull,
 		return nil, nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%v)", request).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%v)", request).WithStopwatch().Entering().Exiting()
 	defer fail.OnExitLogError(&ferr)
 	defer fail.OnPanic(&ferr)
 
@@ -384,7 +385,7 @@ func (s stack) WaitHostReady(hostParam stacks.HostParameter, timeout time.Durati
 		return nil, xerr
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).Entering()
 	defer tracer.Exiting()
 	defer fail.OnExitLogError(&ferr, tracer.TraceMessage(""))
 
@@ -467,7 +468,7 @@ func (s stack) ClearHostStartupScript(hostParam stacks.HostParameter) (ferr fail
 		)
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering()
 	defer tracer.Exiting()
 	defer fail.OnPanic(&ferr)
 
@@ -491,7 +492,7 @@ func (s stack) InspectHost(hostParam stacks.HostParameter) (host *abstract.HostF
 		)
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering()
 	defer tracer.Exiting()
 	defer fail.OnPanic(&ferr)
 
@@ -655,7 +656,7 @@ func (s stack) DeleteHost(hostParam stacks.HostParameter) (ferr fail.Error) {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -700,7 +701,7 @@ func (s stack) ListHosts(detailed bool) (_ abstract.HostList, ferr fail.Error) {
 		return emptyList, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(detailed=%v)", detailed).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(detailed=%v)", detailed).Entering().Exiting()
 
 	resp, xerr := s.rpcListInstances()
 	if xerr != nil {
@@ -746,7 +747,7 @@ func (s stack) StopHost(hostParam stacks.HostParameter, gracefully bool) fail.Er
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering().Exiting()
 
 	return s.rpcStopInstance(ahf.Core.ID)
 }
@@ -761,7 +762,7 @@ func (s stack) StartHost(hostParam stacks.HostParameter) fail.Error {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering().Exiting()
 
 	return s.rpcStartInstance(ahf.Core.ID)
 }
@@ -776,7 +777,7 @@ func (s stack) RebootHost(hostParam stacks.HostParameter) fail.Error {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).Entering().Exiting()
 
 	if xerr := s.rpcStopInstance(ahf.Core.ID); xerr != nil {
 		return xerr
@@ -808,7 +809,7 @@ func (s stack) ListAvailabilityZones() (_ map[string]bool, ferr fail.Error) {
 		return emptyMap, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).Entering().Exiting()
 
 	resp, xerr := s.rpcListZones()
 	if xerr != nil {
@@ -829,7 +830,7 @@ func (s stack) ListRegions() (_ []string, ferr fail.Error) {
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).Entering().Exiting()
 
 	resp, xerr := s.rpcListRegions()
 	if xerr != nil {
@@ -862,7 +863,7 @@ func (s stack) BindSecurityGroupToHost(sgParam stacks.SecurityGroupParameter, ho
 		}
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).Entering().Exiting()
 
 	return s.rpcAddTagsToInstance(ahf.GetID(), []string{asg.GetID()})
 }
@@ -884,7 +885,7 @@ func (s stack) UnbindSecurityGroupFromHost(sgParam stacks.SecurityGroupParameter
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.gcp") || tracing.ShouldTrace("stacks.compute")).Entering().Exiting()
 
 	return s.rpcRemoveTagsFromInstance(ahf.GetID(), []string{asg.GetID()})
 }

--- a/lib/server/iaas/stacks/gcp/network.go
+++ b/lib/server/iaas/stacks/gcp/network.go
@@ -17,6 +17,7 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -58,7 +59,7 @@ func (s stack) CreateNetwork(req abstract.NetworkRequest) (*abstract.Network, fa
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", req.Name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", req.Name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	if _, xerr := s.rpcGetNetworkByName(req.Name); xerr != nil {
@@ -102,7 +103,7 @@ func (s stack) InspectNetwork(id string) (*abstract.Network, fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcGetNetworkByID(id)
@@ -122,7 +123,7 @@ func (s stack) InspectNetworkByName(name string) (*abstract.Network, fail.Error)
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcGetNetworkByName(name)
@@ -149,7 +150,7 @@ func (s stack) ListNetworks() ([]*abstract.Network, fail.Error) {
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcListNetworks()
@@ -173,7 +174,7 @@ func (s stack) DeleteNetwork(ref string) (ferr fail.Error) {
 		return fail.InvalidParameterError("ref", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", ref).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", ref).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	metadata := true
@@ -218,7 +219,7 @@ func (s stack) CreateVIP(networkID, subnetID, name string, securityGroups []stri
 		return nil, fail.InvalidParameterError("subnetID", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", networkID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", networkID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return nil, fail.NotImplementedError("CreateVIP() not implemented yet") // FIXME: Technical debt
@@ -233,7 +234,7 @@ func (s stack) AddPublicIPToVIP(vip *abstract.VirtualIP) fail.Error {
 		return fail.InvalidParameterCannotBeNilError("vip")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%v)", vip).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%v)", vip).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return fail.NotImplementedError("AddPublicIPToVIP() not implemented yet") // FIXME: Technical debt
@@ -251,7 +252,7 @@ func (s stack) BindHostToVIP(vip *abstract.VirtualIP, hostID string) fail.Error 
 		return fail.InvalidParameterError("networkID", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%v, %s)", vip, hostID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%v, %s)", vip, hostID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return fail.NotImplementedError("BindHostToVIP() not implemented yet") // FIXME: Technical debt
@@ -269,7 +270,7 @@ func (s stack) UnbindHostFromVIP(vip *abstract.VirtualIP, hostID string) fail.Er
 		return fail.InvalidParameterError("networkID", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%v, %s)", vip, hostID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%v, %s)", vip, hostID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return fail.NotImplementedError("UnbindHostFromVIP() not implemented yet") // FIXME: Technical debt
@@ -284,7 +285,7 @@ func (s stack) DeleteVIP(vip *abstract.VirtualIP) fail.Error {
 		return fail.InvalidParameterCannotBeNilError("vip")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%v)", vip).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%v)", vip).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return fail.NotImplementedError("DeleteVIP() not implemented yet") // FIXME: Technical debt
@@ -326,7 +327,7 @@ func (s stack) CreateSubnet(req abstract.SubnetRequest) (_ *abstract.Subnet, fer
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", req.Name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", req.Name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	an, xerr := s.InspectNetwork(req.NetworkID)
@@ -389,7 +390,7 @@ func (s stack) InspectSubnet(id string) (*abstract.Subnet, fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcGetSubnetByID(id)
@@ -406,7 +407,7 @@ func (s stack) InspectSubnetByName(networkRef, name string) (_ *abstract.Subnet,
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcGetSubnetByName(name)
@@ -433,7 +434,7 @@ func (s stack) ListSubnets(networkRef string) (_ []*abstract.Subnet, ferr fail.E
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var (
@@ -491,7 +492,7 @@ func (s stack) DeleteSubnet(id string) (ferr fail.Error) {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Delete NAT route

--- a/lib/server/iaas/stacks/gcp/securitygroup.go
+++ b/lib/server/iaas/stacks/gcp/securitygroup.go
@@ -17,6 +17,7 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -43,7 +44,7 @@ func (s stack) ListSecurityGroups(networkRef string) ([]*abstract.SecurityGroup,
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.securitygroup") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.securitygroup") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return emptySlice, nil
@@ -59,7 +60,7 @@ func (s stack) CreateSecurityGroup(networkRef, name, description string, rules a
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("name")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	auuid, err := uuid.NewV4()
@@ -185,7 +186,7 @@ func (s stack) DeleteSecurityGroup(asg *abstract.SecurityGroup) (ferr fail.Error
 		return fail.InvalidParameterError("sgParam", "must be complete")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	if len(asg.Rules) > 0 {
@@ -236,7 +237,7 @@ func (s stack) ClearSecurityGroup(sgParam stacks.SecurityGroupParameter) (*abstr
 		return nil, fail.InvalidParameterError("sgParam", "must be complete")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", asg.ID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	if len(asg.Rules) > 0 {
@@ -276,7 +277,7 @@ func (s stack) AddRuleToSecurityGroup(sgParam stacks.SecurityGroupParameter, rul
 		return nil, fail.InvalidParameterCannotBeNilError("rule")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", sgLabel).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s)", sgLabel).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	if rule.EtherType == ipversion.IPv6 {
@@ -318,7 +319,7 @@ func (s stack) DeleteRuleFromSecurityGroup(sgParam stacks.SecurityGroupParameter
 		return nil, fail.InvalidParameterCannotBeNilError("rule")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s, %v)", sgLabel, rule).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "(%s, %v)", sgLabel, rule).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return nil, fail.NotImplementedError()
@@ -336,7 +337,7 @@ func (s stack) DisableSecurityGroup(asg *abstract.SecurityGroup) fail.Error {
 		return fail.InvalidParameterError("asg", "must be complete")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", asg.GetName()).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", asg.GetName()).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	for _, v := range asg.Rules {
@@ -371,7 +372,7 @@ func (s stack) EnableSecurityGroup(asg *abstract.SecurityGroup) fail.Error {
 		return fail.InvalidParameterError("asg", "must be complete")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", asg.GetName()).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.gcp"), "('%s')", asg.GetName()).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	for _, v := range asg.Rules {

--- a/lib/server/iaas/stacks/gcp/volume.go
+++ b/lib/server/iaas/stacks/gcp/volume.go
@@ -53,7 +53,7 @@ func (s stack) CreateVolume(request abstract.VolumeRequest) (_ *abstract.Volume,
 		return nil, fail.InvalidParameterError("request.Size", "cannot be negative integer or 0")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// TODO: validate content of request
@@ -102,7 +102,7 @@ func (s stack) InspectVolume(ref string) (_ *abstract.Volume, ferr fail.Error) {
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("ref")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s)", ref).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s)", ref).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcGetDisk(ref)
@@ -140,7 +140,7 @@ func (s stack) ListVolumes() ([]*abstract.Volume, fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var out []*abstract.Volume
@@ -193,7 +193,7 @@ func (s stack) DeleteVolume(ref string) fail.Error {
 		return fail.InvalidParameterCannotBeEmptyStringError("ref")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s)", ref).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s)", ref).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcDeleteDisk(ref)
@@ -211,7 +211,7 @@ func (s stack) CreateVolumeAttachment(request abstract.VolumeAttachmentRequest) 
 		return "", fail.InvalidParameterCannotBeEmptyStringError("request.HostID")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "('%s')", request.Name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "('%s')", request.Name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcCreateDiskAttachment(request.VolumeID, request.HostID)
@@ -234,7 +234,7 @@ func (s stack) InspectVolumeAttachment(hostRef, vaID string) (*abstract.VolumeAt
 		return nilA, fail.InvalidParameterCannotBeEmptyStringError("vaID")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s, %s)", hostRef, vaID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s, %s)", hostRef, vaID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	serverID, diskID := extractFromAttachmentID(vaID)
@@ -327,7 +327,7 @@ func (s stack) DeleteVolumeAttachment(serverRef, vaID string) fail.Error {
 		return fail.InvalidParameterCannotBeEmptyStringError("vaID")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s, %s)", serverRef, vaID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s, %s)", serverRef, vaID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcDeleteDiskAttachment(vaID)
@@ -342,7 +342,7 @@ func (s stack) ListVolumeAttachments(serverRef string) ([]*abstract.VolumeAttach
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("serverRef")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s)", serverRef).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.volume") || tracing.ShouldTrace("stack.gcp"), "(%s)", serverRef).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var vats []*abstract.VolumeAttachment

--- a/lib/server/iaas/stacks/huaweicloud/compute.go
+++ b/lib/server/iaas/stacks/huaweicloud/compute.go
@@ -1519,7 +1519,7 @@ func (s stack) enableHostRouterMode(host *abstract.HostFull) fail.Error {
 func (s stack) disableHostRouterMode(host *abstract.HostFull) fail.Error {
 	portID, xerr := s.getOpenstackPortID(host)
 	if xerr != nil {
-		return fail.NewError("failed to disable Router Mode on host '%s'", host.Core.Name)
+		return fail.NewErrorWithCause(xerr, "failed to disable Router Mode on host '%s'", host.Core.Name)
 	}
 	if portID == nil {
 		return fail.NewError(

--- a/lib/server/iaas/stacks/huaweicloud/compute.go
+++ b/lib/server/iaas/stacks/huaweicloud/compute.go
@@ -17,6 +17,7 @@
 package huaweicloud
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -306,7 +307,7 @@ func (s stack) ListAvailabilityZones() (list map[string]bool, ferr fail.Error) {
 		return emptyMap, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("Stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("Stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").Entering()
 	defer tracer.Exiting()
 	defer fail.OnExitLogError(&ferr, tracer.TraceMessage(""))
 
@@ -420,7 +421,7 @@ func (s stack) CreateHost(request abstract.HostRequest) (host *abstract.HostFull
 		return nil, nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.compute"), "(%s)", request.ResourceName).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.compute"), "(%s)", request.ResourceName).WithStopwatch().Entering().Exiting()
 	defer fail.OnPanic(&ferr)
 
 	// msgFail := "failed to create Host resource: %s"
@@ -848,7 +849,7 @@ func (s stack) InspectImage(id string) (_ *abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("Stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("Stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var img *images.Image
@@ -950,7 +951,7 @@ func (s stack) ListImages(bool) (imgList []*abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering()
 	defer tracer.Exiting()
 	defer fail.OnExitLogError(&ferr, tracer.TraceMessage(""))
 
@@ -990,7 +991,7 @@ func (s stack) ListTemplates(bool) ([]*abstract.HostTemplate, fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("Stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("Stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	opts := flavors.ListOpts{}

--- a/lib/server/iaas/stacks/huaweicloud/error.go
+++ b/lib/server/iaas/stacks/huaweicloud/error.go
@@ -17,6 +17,7 @@
 package huaweicloud
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -37,7 +38,7 @@ import (
 // NormalizeError translates gophercloud or openstack error to SafeScale error
 func NormalizeError(err error) fail.Error {
 	if err != nil {
-		tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks") || tracing.ShouldTrace("stack.openstack"), " Normalizing error").Entering()
+		tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks") || tracing.ShouldTrace("stack.openstack"), " Normalizing error").Entering()
 		defer tracer.Exiting()
 
 		switch e := err.(type) {
@@ -214,7 +215,7 @@ func reduceOpenstackError(errorName string, in []byte) (ferr fail.Error) {
 	}()
 	defer fail.OnPanic(&ferr)
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks") || tracing.ShouldTrace("stack.openstack"), ": Normalizing error").Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks") || tracing.ShouldTrace("stack.openstack"), ": Normalizing error").Entering()
 	defer tracer.Exiting()
 
 	fn, ok := errorFuncMap[errorName]

--- a/lib/server/iaas/stacks/huaweicloud/network.go
+++ b/lib/server/iaas/stacks/huaweicloud/network.go
@@ -17,6 +17,7 @@
 package huaweicloud
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -391,7 +392,7 @@ func (s stack) CreateSubnet(req abstract.SubnetRequest) (subnet *abstract.Subnet
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true, "(%s)", req.Name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true, "(%s)", req.Name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var xerr fail.Error
@@ -572,7 +573,7 @@ func (s stack) inspectOpenstackSubnet(id string) (*abstract.Subnet, fail.Error) 
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	as := abstract.NewSubnet()
 	var sn *subnets.Subnet

--- a/lib/server/iaas/stacks/huaweicloud/stack.go
+++ b/lib/server/iaas/stacks/huaweicloud/stack.go
@@ -17,6 +17,7 @@
 package huaweicloud
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -309,7 +310,7 @@ func (s stack) ListRegions() (list []string, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
 
 	var allPages pagination.Page
 	xerr := stacks.RetryableRemoteCall(
@@ -347,7 +348,7 @@ func (s stack) InspectTemplate(id string) (template *abstract.HostTemplate, ferr
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Try to get template
@@ -381,7 +382,7 @@ func (s stack) CreateKeyPair(name string) (*abstract.KeyPair, fail.Error) {
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return abstract.NewKeyPair(name)
@@ -396,7 +397,7 @@ func (s stack) InspectKeyPair(id string) (*abstract.KeyPair, fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	kp, err := keypairs.Get(s.ComputeClient, id, nil).Extract()
@@ -418,7 +419,7 @@ func (s stack) ListKeyPairs() ([]*abstract.KeyPair, fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
 
 	var kpList []*abstract.KeyPair
 	xerr := stacks.RetryableRemoteCall(
@@ -462,7 +463,7 @@ func (s stack) DeleteKeyPair(id string) fail.Error {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	xerr := stacks.RetryableRemoteCall(
 		func() error {
@@ -661,7 +662,7 @@ func (s stack) GetHostState(hostParam stacks.HostParameter) (hoststate.Enum, fai
 		return hoststate.Unknown, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
 
 	host, xerr := s.InspectHost(hostParam)
 	if xerr != nil {
@@ -680,7 +681,7 @@ func (s stack) StopHost(hostParam stacks.HostParameter, gracefully bool) fail.Er
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	return stacks.RetryableRemoteCall(
 		func() error {
@@ -700,7 +701,7 @@ func (s stack) StartHost(hostParam stacks.HostParameter) fail.Error {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	return stacks.RetryableRemoteCall(
 		func() error {
@@ -720,7 +721,7 @@ func (s stack) RebootHost(hostParam stacks.HostParameter) fail.Error {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	// Try first a soft reboot, and if it fails (because host isn't in ACTIVE state), tries a hard reboot
 	return stacks.RetryableRemoteCall(
@@ -749,7 +750,7 @@ func (s stack) ResizeHost(hostParam stacks.HostParameter, request abstract.HostS
 		return nil, xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	logrus.Debugf("Trying to resize a Host...")
 	// servers.Resize()
@@ -769,7 +770,7 @@ func (s stack) WaitHostState(hostParam stacks.HostParameter, state hoststate.Enu
 		return nil, xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s, %s, %v)", hostLabel,
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s, %s, %v)", hostLabel,
 		state.String(), timeout).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
@@ -956,7 +957,7 @@ func (s stack) DeleteVolume(id string) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeEmptyStringError("id")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "("+id+")").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "("+id+")").WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -1008,7 +1009,7 @@ func (s stack) CreateVolumeAttachment(request abstract.VolumeAttachmentRequest) 
 		return "", fail.InvalidParameterCannotBeEmptyStringError("request.Name")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "("+request.Name+")").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "("+request.Name+")").WithStopwatch().Entering().Exiting()
 
 	// Creates the attachment
 	var va *volumeattach.VolumeAttachment
@@ -1039,7 +1040,7 @@ func (s stack) InspectVolumeAttachment(serverID, id string) (*abstract.VolumeAtt
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("id")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "('"+serverID+"', '"+id+"')").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "('"+serverID+"', '"+id+"')").WithStopwatch().Entering().Exiting()
 
 	var va *volumeattach.VolumeAttachment
 	xerr := stacks.RetryableRemoteCall(
@@ -1069,7 +1070,7 @@ func (s stack) ListVolumeAttachments(serverID string) ([]*abstract.VolumeAttachm
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("serverID")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "('"+serverID+"')").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "('"+serverID+"')").WithStopwatch().Entering().Exiting()
 
 	var vs []*abstract.VolumeAttachment
 	xerr := stacks.RetryableRemoteCall(
@@ -1112,7 +1113,7 @@ func (s stack) DeleteVolumeAttachment(serverID, vaID string) fail.Error {
 		return fail.InvalidParameterCannotBeEmptyStringError("vaID")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "('"+serverID+"', '"+vaID+"')").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "('"+serverID+"', '"+vaID+"')").WithStopwatch().Entering().Exiting()
 
 	return stacks.RetryableRemoteCall(
 		func() error {

--- a/lib/server/iaas/stacks/openstack/compute.go
+++ b/lib/server/iaas/stacks/openstack/compute.go
@@ -17,6 +17,7 @@
 package openstack
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -57,7 +58,7 @@ func (s stack) ListRegions() (list []string, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
 
 	var allPages pagination.Page
 	xerr := stacks.RetryableRemoteCall(
@@ -95,7 +96,7 @@ func (s stack) ListAvailabilityZones() (list map[string]bool, ferr fail.Error) {
 		return emptyMap, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").Entering()
 	defer tracer.Exiting()
 	defer fail.OnExitLogError(&ferr, tracer.TraceMessage(""))
 
@@ -139,7 +140,7 @@ func (s stack) ListImages(bool) (imgList []*abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering()
 	defer tracer.Exiting()
 	defer fail.OnExitLogError(&ferr, tracer.TraceMessage(""))
 
@@ -181,7 +182,7 @@ func (s stack) InspectImage(id string) (_ *abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var img *images.Image
@@ -213,7 +214,7 @@ func (s stack) InspectTemplate(id string) (template *abstract.HostTemplate, ferr
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Try to get template
@@ -245,7 +246,7 @@ func (s stack) ListTemplates(bool) ([]*abstract.HostTemplate, fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	opts := flavors.ListOpts{}
@@ -303,7 +304,7 @@ func (s stack) CreateKeyPair(name string) (*abstract.KeyPair, fail.Error) {
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return abstract.NewKeyPair(name)
@@ -319,7 +320,7 @@ func (s stack) InspectKeyPair(id string) (*abstract.KeyPair, fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	kp, err := keypairs.Get(s.ComputeClient, id, nil).Extract()
@@ -341,7 +342,7 @@ func (s stack) ListKeyPairs() ([]*abstract.KeyPair, fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
 
 	var kpList []*abstract.KeyPair
 	xerr := stacks.RetryableRemoteCall(
@@ -385,7 +386,7 @@ func (s stack) DeleteKeyPair(id string) fail.Error {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	xerr := stacks.RetryableRemoteCall(
 		func() error {
@@ -458,7 +459,7 @@ func (s stack) InspectHost(hostParam stacks.HostParameter) (*abstract.HostFull, 
 		return nil, xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostLabel).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -614,7 +615,7 @@ func (s stack) InspectHostByName(name string) (*abstract.HostFull, fail.Error) {
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "('%s')", name).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "('%s')", name).WithStopwatch().Entering().Exiting()
 
 	// Gophercloud doesn't propose the way to get a host by name, but OpenStack knows how to do it...
 	r := servers.GetResult{}
@@ -665,7 +666,7 @@ func (s stack) CreateHost(request abstract.HostRequest) (host *abstract.HostFull
 		return nil, nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)",
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)",
 		request.ResourceName).WithStopwatch().Entering().Exiting()
 	defer fail.OnPanic(&ferr)
 
@@ -1183,7 +1184,7 @@ func (s stack) WaitHostState(hostParam stacks.HostParameter, state hoststate.Enu
 		return nil, xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s, %s, %v)", hostLabel,
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s, %s, %v)", hostLabel,
 		state.String(), timeout).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
@@ -1280,7 +1281,7 @@ func (s stack) GetHostState(hostParam stacks.HostParameter) (hoststate.Enum, fai
 		return hoststate.Unknown, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
 
 	host, xerr := s.InspectHost(hostParam)
 	if xerr != nil {
@@ -1296,7 +1297,7 @@ func (s stack) ListHosts(details bool) (abstract.HostList, fail.Error) {
 		return emptyList, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "").WithStopwatch().Entering().Exiting()
 
 	hostList := abstract.HostList{}
 	xerr := stacks.RetryableRemoteCall(
@@ -1381,7 +1382,7 @@ func (s stack) DeleteHost(hostParam stacks.HostParameter) fail.Error {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	// Detach floating IP
 	if s.cfgOpts.UseFloatingIP {
@@ -1562,7 +1563,7 @@ func (s stack) StopHost(hostParam stacks.HostParameter, gracefully bool) fail.Er
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	return stacks.RetryableRemoteCall(
 		func() error {
@@ -1582,7 +1583,7 @@ func (s stack) RebootHost(hostParam stacks.HostParameter) fail.Error {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	// Try first a soft reboot, and if it fails (because host isn't in ACTIVE state), tries a hard reboot
 	return stacks.RetryableRemoteCall(
@@ -1611,7 +1612,7 @@ func (s stack) StartHost(hostParam stacks.HostParameter) fail.Error {
 		return xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	return stacks.RetryableRemoteCall(
 		func() error {
@@ -1631,7 +1632,7 @@ func (s stack) ResizeHost(hostParam stacks.HostParameter, request abstract.HostS
 		return nil, xerr
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.openstack") || tracing.ShouldTrace("stacks.compute"), "(%s)", hostRef).WithStopwatch().Entering().Exiting()
 
 	// TODO: RESIZE Resize IPAddress HERE
 	logrus.Warn("Trying to resize a Host...")

--- a/lib/server/iaas/stacks/openstack/error.go
+++ b/lib/server/iaas/stacks/openstack/error.go
@@ -17,6 +17,7 @@
 package openstack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -36,7 +37,7 @@ import (
 func NormalizeError(err error) fail.Error {
 	if err != nil {
 
-		tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks") || tracing.ShouldTrace("stack.openstack"), " Normalizing error").Entering()
+		tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks") || tracing.ShouldTrace("stack.openstack"), " Normalizing error").Entering()
 		defer tracer.Exiting()
 
 		switch e := err.(type) {
@@ -165,7 +166,7 @@ var errorFuncMap = map[string]func(string) fail.Error{
 func reduceOpenstackError(errorName string, in []byte) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks") || tracing.ShouldTrace("stack.openstack"), ": Normalizing error").Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks") || tracing.ShouldTrace("stack.openstack"), ": Normalizing error").Entering()
 	defer tracer.Exiting()
 
 	fn, ok := errorFuncMap[errorName]

--- a/lib/server/iaas/stacks/openstack/network.go
+++ b/lib/server/iaas/stacks/openstack/network.go
@@ -17,6 +17,7 @@
 package openstack
 
 import (
+	"context"
 	"net"
 	"strings"
 
@@ -74,7 +75,7 @@ func (s stack) CreateNetwork(req abstract.NetworkRequest) (newNet *abstract.Netw
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "(%s)", req.Name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "(%s)", req.Name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Checks if CIDR is valid...
@@ -146,7 +147,7 @@ func (s stack) InspectNetworkByName(name string) (*abstract.Network, fail.Error)
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "(%s)", name).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "(%s)", name).WithStopwatch().Entering().Exiting()
 
 	// Gophercloud doesn't propose the way to get a host by name, but OpenStack knows how to do it...
 	r := networks.GetResult{}
@@ -192,7 +193,7 @@ func (s stack) InspectNetwork(id string) (*abstract.Network, fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	// If not found, we look for any network from provider
 	// 1st try with id
@@ -233,7 +234,7 @@ func (s stack) ListNetworks() ([]*abstract.Network, fail.Error) {
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "").WithStopwatch().Entering().Exiting()
 
 	// Retrieve a pager (i.e. a paginated collection)
 	var netList []*abstract.Network
@@ -280,7 +281,7 @@ func (s stack) DeleteNetwork(id string) fail.Error {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	var network *networks.Network
 	xerr := stacks.RetryableRemoteCall(
@@ -352,7 +353,7 @@ func (s stack) CreateSubnet(req abstract.SubnetRequest) (newNet *abstract.Subnet
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "(%s)", req.Name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "(%s)", req.Name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Checks if CIDR is valid...
@@ -470,7 +471,7 @@ func (s stack) InspectSubnet(id string) (_ *abstract.Subnet, ferr fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	as := abstract.NewSubnet()
 	var sn *subnets.Subnet
@@ -504,7 +505,7 @@ func (s stack) InspectSubnetByName(networkRef, name string) (subnet *abstract.Su
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "(%s)", name).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "(%s)", name).WithStopwatch().Entering().Exiting()
 
 	listOpts := subnets.ListOpts{
 		Name: name,
@@ -583,7 +584,7 @@ func (s stack) ListSubnets(networkID string) ([]*abstract.Subnet, fail.Error) {
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.network"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.network"), "").WithStopwatch().Entering().Exiting()
 
 	listOpts := subnets.ListOpts{}
 	if networkID != "" {
@@ -627,7 +628,7 @@ func (s stack) DeleteSubnet(id string) fail.Error {
 		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.openstack"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.openstack"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {

--- a/lib/server/iaas/stacks/openstack/support.go
+++ b/lib/server/iaas/stacks/openstack/support.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/CS-SI/SafeScale/v22/lib/utils/debug"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/fail"
 )
 
@@ -65,6 +66,7 @@ func reinterpretGophercloudErrorCode(gopherErr error, success []int64, transpare
 	if gopherErr != nil {
 		code, err := GetUnexpectedGophercloudErrorCode(gopherErr)
 		if err != nil {
+			debug.IgnoreError(err)
 			return gopherErr
 		}
 		if code == 0 {

--- a/lib/server/iaas/stacks/openstack/volume.go
+++ b/lib/server/iaas/stacks/openstack/volume.go
@@ -100,7 +100,7 @@ func (s stack) CreateVolume(request abstract.VolumeRequest) (volume *abstract.Vo
 	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "(%s)", request.Name).WithStopwatch().Entering().Exiting()
 
 	az, xerr := s.SelectedAvailabilityZone()
-	if xerr != nil {
+	if xerr != nil { // nolint
 		return nil, abstract.ResourceDuplicateError("volume", request.Name)
 	}
 

--- a/lib/server/iaas/stacks/openstack/volume.go
+++ b/lib/server/iaas/stacks/openstack/volume.go
@@ -17,6 +17,7 @@
 package openstack
 
 import (
+	"context"
 	"strings"
 
 	"github.com/CS-SI/SafeScale/v22/lib/utils/valid"
@@ -96,7 +97,7 @@ func (s stack) CreateVolume(request abstract.VolumeRequest) (volume *abstract.Vo
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("request.Name")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "(%s)", request.Name).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "(%s)", request.Name).WithStopwatch().Entering().Exiting()
 
 	az, xerr := s.SelectedAvailabilityZone()
 	if xerr != nil {
@@ -182,7 +183,7 @@ func (s stack) InspectVolume(id string) (*abstract.Volume, fail.Error) {
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("id")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "(%s)", id).WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "(%s)", id).WithStopwatch().Entering().Exiting()
 
 	var vol *volumesv2.Volume
 	xerr := stacks.RetryableRemoteCall(
@@ -217,7 +218,7 @@ func (s stack) ListVolumes() ([]*abstract.Volume, fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "").WithStopwatch().Entering().Exiting()
 
 	var vs []*abstract.Volume
 	xerr := stacks.RetryableRemoteCall(
@@ -263,7 +264,7 @@ func (s stack) DeleteVolume(id string) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeEmptyStringError("id")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "("+id+")").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "("+id+")").WithStopwatch().Entering().Exiting()
 
 	timings, xerr := s.Timings()
 	if xerr != nil {
@@ -315,7 +316,7 @@ func (s stack) CreateVolumeAttachment(request abstract.VolumeAttachmentRequest) 
 		return "", fail.InvalidParameterCannotBeEmptyStringError("request.Name")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "("+request.Name+")").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "("+request.Name+")").WithStopwatch().Entering().Exiting()
 
 	// Creates the attachment
 	var va *volumeattach.VolumeAttachment
@@ -347,7 +348,7 @@ func (s stack) InspectVolumeAttachment(serverID, id string) (*abstract.VolumeAtt
 		return nilA, fail.InvalidParameterCannotBeEmptyStringError("id")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "('"+serverID+"', '"+id+"')").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "('"+serverID+"', '"+id+"')").WithStopwatch().Entering().Exiting()
 
 	var va *volumeattach.VolumeAttachment
 	xerr := stacks.RetryableRemoteCall(
@@ -377,7 +378,7 @@ func (s stack) ListVolumeAttachments(serverID string) ([]*abstract.VolumeAttachm
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("serverID")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "('"+serverID+"')").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "('"+serverID+"')").WithStopwatch().Entering().Exiting()
 
 	var vs []*abstract.VolumeAttachment
 	xerr := stacks.RetryableRemoteCall(
@@ -424,7 +425,7 @@ func (s stack) DeleteVolumeAttachment(serverID, vaID string) fail.Error {
 		return fail.InvalidParameterCannotBeEmptyStringError("vaID")
 	}
 
-	defer debug.NewTracer(nil, tracing.ShouldTrace("stack.volume"), "('"+serverID+"', '"+vaID+"')").WithStopwatch().Entering().Exiting()
+	defer debug.NewTracer(context.Background(), tracing.ShouldTrace("stack.volume"), "('"+serverID+"', '"+vaID+"')").WithStopwatch().Entering().Exiting()
 
 	return stacks.RetryableRemoteCall(
 		func() error {

--- a/lib/server/iaas/stacks/outscale/compute.go
+++ b/lib/server/iaas/stacks/outscale/compute.go
@@ -18,6 +18,7 @@ package outscale
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"sort"
@@ -69,7 +70,7 @@ func (s stack) ListImages(bool) (_ []*abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadImages(nil)
@@ -204,7 +205,7 @@ func (s stack) ListTemplates(bool) (_ []*abstract.HostTemplate, ferr fail.Error)
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	templates := make([]*abstract.HostTemplate, len(s.templates))
@@ -334,7 +335,7 @@ func (s stack) InspectImage(id string) (_ *abstract.Image, ferr fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	defer func() {
@@ -370,7 +371,7 @@ func (s stack) InspectTemplate(id string) (_ *abstract.HostTemplate, ferr fail.E
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.parseTemplateID(id)
@@ -516,7 +517,7 @@ func (s stack) WaitHostState(hostParam stacks.HostParameter, state hoststate.Enu
 		return nil, xerr
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s, %s, %v)",
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s, %s, %v)",
 		hostLabel, state.String(), timeout).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
@@ -824,7 +825,7 @@ func (s stack) CreateHost(request abstract.HostRequest) (ahf *abstract.HostFull,
 		)
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%v)", request).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%v)", request).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Get or create password
@@ -1113,7 +1114,7 @@ func (s stack) DeleteHost(hostParam stacks.HostParameter) (ferr fail.Error) {
 		return xerr
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostLabel).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostLabel).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	publicIPs, xerr := s.rpcReadPublicIPsOfVM(ahf.Core.ID)
@@ -1172,7 +1173,7 @@ func (s stack) InspectHost(hostParam stacks.HostParameter) (ahf *abstract.HostFu
 		return nil, xerr
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostLabel).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostLabel).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var vm osc.Vm
@@ -1223,7 +1224,7 @@ func (s stack) GetHostState(hostParam stacks.HostParameter) (_ hoststate.Enum, f
 	if valid.IsNil(s) {
 		return hoststate.Unknown, fail.InvalidInstanceError()
 	}
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	ahf, _, xerr := stacks.ValidateHostParameter(hostParam)
@@ -1241,7 +1242,7 @@ func (s stack) ListHosts(details bool) (_ abstract.HostList, ferr fail.Error) {
 		return emptyList, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadVMs(nil)
@@ -1288,7 +1289,7 @@ func (s stack) StopHost(hostParam stacks.HostParameter, gracefully bool) (ferr f
 		return xerr
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostRef).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostRef).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcStopVMs([]string{ahf.Core.ID})
@@ -1304,7 +1305,7 @@ func (s stack) StartHost(hostParam stacks.HostParameter) (ferr fail.Error) {
 		return xerr
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostRef).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostRef).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcStartVMs([]string{ahf.Core.ID})
@@ -1320,7 +1321,7 @@ func (s stack) RebootHost(hostParam stacks.HostParameter) (ferr fail.Error) {
 		return xerr
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostRef).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", hostRef).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcRebootVMs([]string{ahf.Core.ID})
@@ -1353,7 +1354,7 @@ func (s stack) ResizeHost(
 		return nil, xerr
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s, %v)",
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.compute") || tracing.ShouldTrace("stack.outscale")*/, "(%s, %v)",
 		hostRef, sizing).WithStopwatch().Entering()
 	defer tracer.Exiting()
 

--- a/lib/server/iaas/stacks/outscale/error.go
+++ b/lib/server/iaas/stacks/outscale/error.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/CS-SI/SafeScale/v21/lib/utils/debug"
+	"github.com/CS-SI/SafeScale/v22/lib/utils/debug"
 	"github.com/outscale/osc-sdk-go/osc"
 
 	"github.com/CS-SI/SafeScale/v22/lib/utils/fail"

--- a/lib/server/iaas/stacks/outscale/error.go
+++ b/lib/server/iaas/stacks/outscale/error.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"reflect"
 
+	"github.com/CS-SI/SafeScale/v21/lib/utils/debug"
 	"github.com/outscale/osc-sdk-go/osc"
 
 	"github.com/CS-SI/SafeScale/v22/lib/utils/fail"
@@ -120,6 +121,7 @@ func normalizeError(err error) fail.Error {
 				if _, ok := normalized.(*fail.ErrUnknown); ok {
 					errFromHTTP, xerr := normalizeFromHTTPReturnCode(realErr.httpResponse)
 					if xerr != nil { // we failed using the http return code, so send the normalized error
+						debug.IgnoreError(xerr)
 						return normalized
 					}
 					return errFromHTTP // we got something
@@ -133,6 +135,7 @@ func normalizeError(err error) fail.Error {
 				if _, ok := normalized.(*fail.ErrUnknown); ok {
 					errFromHTTP, xerr := normalizeFromHTTPReturnCode(realErr.httpResponse)
 					if xerr != nil { // we failed using the http return code, so send the normalized error
+						debug.IgnoreError(xerr)
 						return normalized
 					}
 					return errFromHTTP // we got something

--- a/lib/server/iaas/stacks/outscale/keypairs.go
+++ b/lib/server/iaas/stacks/outscale/keypairs.go
@@ -17,6 +17,7 @@
 package outscale
 
 import (
+	"context"
 	"encoding/base64"
 
 	"github.com/CS-SI/SafeScale/v22/lib/server/resources/abstract"
@@ -35,7 +36,7 @@ func (s stack) CreateKeyPair(name string) (akp *abstract.KeyPair, ferr fail.Erro
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("name")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale"), "('%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale"), "('%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var xerr fail.Error
@@ -55,7 +56,7 @@ func (s stack) ImportKeyPair(keypair *abstract.KeyPair) (ferr fail.Error) {
 		return fail.InvalidParameterError("keyair", "cannot be nil")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale"), "'%s')", keypair.Name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale"), "'%s')", keypair.Name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcCreateKeypair(keypair.Name, base64.StdEncoding.EncodeToString([]byte(keypair.PublicKey)))
@@ -70,7 +71,7 @@ func (s stack) InspectKeyPair(id string) (akp *abstract.KeyPair, ferr fail.Error
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("name")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale"), "'%s')", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale"), "'%s')", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadKeypairByName(id)
@@ -91,7 +92,7 @@ func (s stack) ListKeyPairs() (_ []*abstract.KeyPair, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadKeypairs(nil)
@@ -119,7 +120,7 @@ func (s stack) DeleteKeyPair(name string) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeEmptyStringError("name")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale"), "'%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale"), "'%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcDeleteKeypair(name)

--- a/lib/server/iaas/stacks/outscale/network.go
+++ b/lib/server/iaas/stacks/outscale/network.go
@@ -17,6 +17,8 @@
 package outscale
 
 import (
+	"context"
+
 	"github.com/CS-SI/SafeScale/v22/lib/utils/valid"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
@@ -60,7 +62,7 @@ func (s stack) CreateNetwork(req abstract.NetworkRequest) (an *abstract.Network,
 	if req.CIDR == "" {
 		req.CIDR = stacks.DefaultNetworkCIDR
 	}
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%v)", req).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%v)", req).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcCreateNetwork(req.Name, req.CIDR)
@@ -253,7 +255,7 @@ func (s stack) InspectNetwork(id string) (_ *abstract.Network, ferr fail.Error) 
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadNetByID(id)
@@ -270,7 +272,7 @@ func (s stack) InspectNetworkByName(name string) (_ *abstract.Network, ferr fail
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "('%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "('%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadNetByName(name)
@@ -288,7 +290,7 @@ func (s stack) ListNetworks() (_ []*abstract.Network, ferr fail.Error) {
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadNets(nil)
@@ -310,7 +312,7 @@ func (s stack) DeleteNetwork(id string) (ferr fail.Error) {
 		return fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Reads NICs that belong to the subnet
@@ -350,7 +352,7 @@ func (s stack) CreateSubnet(req abstract.SubnetRequest) (as *abstract.Subnet, fe
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%v)", req).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%v)", req).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Check if CIDR intersects with VPC cidr; if not, error
@@ -402,7 +404,7 @@ func (s stack) InspectSubnet(id string) (_ *abstract.Subnet, ferr fail.Error) {
 		return nil, fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadSubnetByID(id)
@@ -425,7 +427,7 @@ func (s stack) InspectSubnetByName(networkRef, subnetName string) (_ *abstract.S
 		return nil, fail.InvalidParameterError("subnetName", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s, %s)", networkRef, subnetName).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s, %s)", networkRef, subnetName).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var networkID string
@@ -496,7 +498,7 @@ func (s stack) ListSubnets(networkRef string) (_ []*abstract.Subnet, ferr fail.E
 		return emptySlice, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	if networkRef == "" {
@@ -570,7 +572,7 @@ func (s stack) DeleteSubnet(id string) (ferr fail.Error) {
 		return fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), true /*tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale")*/, "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Reads NIS that belong to the subnet

--- a/lib/server/iaas/stacks/outscale/securitygroup.go
+++ b/lib/server/iaas/stacks/outscale/securitygroup.go
@@ -17,6 +17,8 @@
 package outscale
 
 import (
+	"context"
+
 	"github.com/CS-SI/SafeScale/v22/lib/utils/valid"
 	"github.com/outscale/osc-sdk-go/osc"
 
@@ -36,7 +38,7 @@ func (s stack) ListSecurityGroups(networkID string) (list []*abstract.SecurityGr
 		return list, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.securitygroup") || tracing.ShouldTrace("stack.outscale")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.securitygroup") || tracing.ShouldTrace("stack.outscale")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	groups, xerr := s.rpcReadSecurityGroups(networkID, nil)
@@ -89,7 +91,7 @@ func (s stack) CreateSecurityGroup(networkID, name, description string, rules ab
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("name")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "('%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "('%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcCreateSecurityGroup(networkID, name, description)
@@ -144,7 +146,7 @@ func (s stack) DeleteSecurityGroup(asg *abstract.SecurityGroup) (ferr fail.Error
 		}
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s)", asg.ID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s)", asg.ID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcDeleteSecurityGroup(asg.ID)
@@ -160,7 +162,7 @@ func (s stack) InspectSecurityGroup(sgParam stacks.SecurityGroupParameter) (*abs
 		return nil, xerr
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s)", sgLabel).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s)", sgLabel).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	var group osc.SecurityGroup
@@ -196,7 +198,7 @@ func (s stack) ClearSecurityGroup(sgParam stacks.SecurityGroupParameter) (*abstr
 		}
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s)", sgLabel).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s)", sgLabel).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	group, xerr := s.rpcReadSecurityGroupByID(asg.ID)
@@ -235,7 +237,7 @@ func (s stack) AddRuleToSecurityGroup(sgParam stacks.SecurityGroupParameter, rul
 		}
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s)", sgLabel).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s)", sgLabel).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	if rule.EtherType == ipversion.IPv6 {
@@ -342,7 +344,7 @@ func (s stack) DeleteRuleFromSecurityGroup(sgParam stacks.SecurityGroupParameter
 		}
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s, %s)", sgLabel, rule.Description).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.network") || tracing.ShouldTrace("stack.outscale"), "(%s, %s)", sgLabel, rule.Description).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// IPv6 not supported at Outscale (?)

--- a/lib/server/iaas/stacks/outscale/stack.go
+++ b/lib/server/iaas/stacks/outscale/stack.go
@@ -117,7 +117,7 @@ func New(options *ConfigurationOptions) (_ *stack, ferr fail.Error) { // nolint
 		return nil, fail.InvalidParameterCannotBeNilError("options")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	config := osc.NewConfiguration()
@@ -232,7 +232,7 @@ func (s stack) ListRegions() (_ []string, ferr fail.Error) {
 		return []string{}, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, _, err := s.client.RegionApi.ReadRegions(s.auth, nil)
@@ -255,7 +255,7 @@ func (s stack) ListAvailabilityZones() (az map[string]bool, ferr fail.Error) {
 		return emptyMap, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, _, err := s.client.SubregionApi.ReadSubregions(s.auth, nil)

--- a/lib/server/iaas/stacks/outscale/vip.go
+++ b/lib/server/iaas/stacks/outscale/vip.go
@@ -17,6 +17,7 @@
 package outscale
 
 import (
+	"context"
 	"sort"
 	"strings"
 
@@ -40,7 +41,7 @@ func (s stack) CreateVIP(networkID, subnetID, name string, securityGroups []stri
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale"), "(%s, '%s')", subnetID, name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale"), "(%s, '%s')", subnetID, name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	subnet, xerr := s.InspectSubnet(subnetID)
@@ -137,7 +138,7 @@ func (s stack) DeleteVIP(vip *abstract.VirtualIP) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeNilError("vip")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale"), "(%v)", vip).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale"), "(%v)", vip).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	if xerr := s.rpcDeleteNic(vip.ID); xerr != nil {

--- a/lib/server/iaas/stacks/outscale/volume.go
+++ b/lib/server/iaas/stacks/outscale/volume.go
@@ -17,6 +17,8 @@
 package outscale
 
 import (
+	"context"
+
 	"github.com/CS-SI/SafeScale/v22/lib/server/resources/abstract"
 	"github.com/CS-SI/SafeScale/v22/lib/server/resources/enums/volumespeed"
 	"github.com/CS-SI/SafeScale/v22/lib/server/resources/enums/volumestate"
@@ -36,7 +38,7 @@ func (s stack) CreateVolume(request abstract.VolumeRequest) (_ *abstract.Volume,
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("volume name")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%v)", request).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%v)", request).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	v, xerr := s.InspectVolumeByName(request.Name)
@@ -127,7 +129,7 @@ func (s stack) WaitForVolumeState(volumeID string, state volumestate.Enum) (ferr
 		return fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s)", volumeID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s)", volumeID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	timings, xerr := s.Timings()
@@ -160,7 +162,7 @@ func (s stack) InspectVolume(id string) (av *abstract.Volume, ferr fail.Error) {
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("id")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadVolumeByID(id)
@@ -186,7 +188,7 @@ func (s stack) InspectVolumeByName(name string) (av *abstract.Volume, ferr fail.
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("name")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "('%s')", name).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "('%s')", name).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadVolumeByName(name)
@@ -209,7 +211,7 @@ func (s stack) ListVolumes() (_ []*abstract.Volume, ferr fail.Error) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume")).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume")).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadVolumes(nil)
@@ -242,7 +244,7 @@ func (s stack) DeleteVolume(id string) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeEmptyStringError("id")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s)", id).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s)", id).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	return s.rpcDeleteVolume(id)
@@ -289,7 +291,7 @@ func (s stack) CreateVolumeAttachment(request abstract.VolumeAttachmentRequest) 
 		return "", fail.InvalidParameterCannotBeEmptyStringError("VolumeID")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%v)", request).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%v)", request).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	firstDeviceName, xerr := s.getFirstFreeDeviceName(request.HostID)
@@ -316,7 +318,7 @@ func (s stack) InspectVolumeAttachment(serverID, volumeID string) (_ *abstract.V
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("volumeID")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s, %s)", serverID, volumeID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s, %s)", serverID, volumeID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	resp, xerr := s.rpcReadVolumeByID(volumeID)
@@ -350,7 +352,7 @@ func (s stack) ListVolumeAttachments(serverID string) (_ []*abstract.VolumeAttac
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("serverID")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s)", serverID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s)", serverID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	volumes, err := s.ListVolumes()
@@ -383,7 +385,7 @@ func (s stack) DeleteVolumeAttachment(serverID, volumeID string) (ferr fail.Erro
 		return fail.InvalidParameterCannotBeEmptyStringError("volumeID")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s, %s)", serverID, volumeID).WithStopwatch().Entering()
+	tracer := debug.NewTracer(context.Background(), tracing.ShouldTrace("stacks.outscale") || tracing.ShouldTrace("stack.volume"), "(%s, %s)", serverID, volumeID).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	xerr := s.rpcUnlinkVolume(volumeID)

--- a/lib/server/listeners/cluster.go
+++ b/lib/server/listeners/cluster.go
@@ -117,7 +117,7 @@ func (s *ClusterListener) Create(ctx context.Context, in *protocol.ClusterCreate
 		return nil, xerr
 	}
 
-	return instance.ToProtocol()
+	return instance.ToProtocol(job.Context())
 }
 
 // State returns the status of a cluster
@@ -154,7 +154,7 @@ func (s *ClusterListener) State(ctx context.Context, in *protocol.Reference) (ht
 		return nil, xerr
 	}
 
-	st, xerr := instance.GetState()
+	st, xerr := instance.GetState(job.Context())
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -197,7 +197,7 @@ func (s *ClusterListener) Inspect(ctx context.Context, in *protocol.Reference) (
 		return nil, xerr
 	}
 
-	return instance.ToProtocol()
+	return instance.ToProtocol(job.Context())
 }
 
 // Start ...

--- a/lib/server/listeners/feature.go
+++ b/lib/server/listeners/feature.go
@@ -98,7 +98,7 @@ func (s *FeatureListener) List(ctx context.Context, in *protocol.FeatureListRequ
 			return empty, xerr
 		}
 
-		return converters.FeatureSliceFromResourceToProtocol(list), nil
+		return converters.FeatureSliceFromResourceToProtocol(ctx, list), nil
 
 	case protocol.FeatureTargetType_FT_CLUSTER:
 		clusterInstance, xerr := clusterfactory.Load(job.Context(), job.Service(), targetRef)
@@ -116,7 +116,7 @@ func (s *FeatureListener) List(ctx context.Context, in *protocol.FeatureListRequ
 			return empty, xerr
 		}
 
-		return converters.FeatureSliceFromResourceToProtocol(list), nil
+		return converters.FeatureSliceFromResourceToProtocol(ctx, list), nil
 	}
 
 	// Should not reach this

--- a/lib/server/listeners/host.go
+++ b/lib/server/listeners/host.go
@@ -299,7 +299,7 @@ func (s *HostListener) Create(ctx context.Context, in *protocol.HostDefinition) 
 				return nil, xerr
 			}
 
-			xerr = subnetInstance.Review(
+			xerr = subnetInstance.Review(ctx,
 				func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 					as, ok := clonable.(*abstract.Subnet)
 					if !ok {
@@ -323,7 +323,7 @@ func (s *HostListener) Create(ctx context.Context, in *protocol.HostDefinition) 
 			return nil, xerr
 		}
 
-		xerr = subnetInstance.Review(
+		xerr = subnetInstance.Review(ctx,
 			func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 				as, ok := clonable.(*abstract.Subnet)
 				if !ok {

--- a/lib/server/listeners/host.go
+++ b/lib/server/listeners/host.go
@@ -934,7 +934,7 @@ func (s *HostListener) ListSecurityGroups(ctx context.Context, in *protocol.Secu
 		return nil, xerr
 	}
 
-	bonds, xerr := hostInstance.ListSecurityGroups(securitygroupstate.All)
+	bonds, xerr := hostInstance.ListSecurityGroups(job.Context(), securitygroupstate.All)
 	if xerr != nil {
 		return nil, xerr
 	}

--- a/lib/server/listeners/host.go
+++ b/lib/server/listeners/host.go
@@ -415,27 +415,25 @@ func (s *HostListener) Resize(ctx context.Context, in *protocol.HostDefinition) 
 	}
 
 	reduce := false
-	xerr = hostInstance.Inspect(
-		func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
-			return props.Inspect(
-				hostproperty.SizingV2, func(clonable data.Clonable) fail.Error {
-					hostSizingV2, ok := clonable.(*propertiesv2.HostSizing)
-					if !ok {
-						return fail.InconsistentError(
-							"'*propertiesv1.HostSizing' expected, '%s' provided", reflect.TypeOf(clonable).String(),
-						)
-					}
+	xerr = hostInstance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+		return props.Inspect(
+			hostproperty.SizingV2, func(clonable data.Clonable) fail.Error {
+				hostSizingV2, ok := clonable.(*propertiesv2.HostSizing)
+				if !ok {
+					return fail.InconsistentError(
+						"'*propertiesv1.HostSizing' expected, '%s' provided", reflect.TypeOf(clonable).String(),
+					)
+				}
 
-					reduce = reduce || (sizing.MinCores < hostSizingV2.RequestedSize.MinCores)
-					reduce = reduce || (sizing.MinRAMSize < hostSizingV2.RequestedSize.MinRAMSize)
-					reduce = reduce || (sizing.MinGPU < hostSizingV2.RequestedSize.MinGPU)
-					reduce = reduce || (sizing.MinCPUFreq < hostSizingV2.RequestedSize.MinCPUFreq)
-					reduce = reduce || (sizing.MinDiskSize < hostSizingV2.RequestedSize.MinDiskSize)
-					return nil
-				},
-			)
-		},
-	)
+				reduce = reduce || (sizing.MinCores < hostSizingV2.RequestedSize.MinCores)
+				reduce = reduce || (sizing.MinRAMSize < hostSizingV2.RequestedSize.MinRAMSize)
+				reduce = reduce || (sizing.MinGPU < hostSizingV2.RequestedSize.MinGPU)
+				reduce = reduce || (sizing.MinCPUFreq < hostSizingV2.RequestedSize.MinCPUFreq)
+				reduce = reduce || (sizing.MinDiskSize < hostSizingV2.RequestedSize.MinDiskSize)
+				return nil
+			},
+		)
+	})
 	if xerr != nil {
 		return nil, xerr
 	}

--- a/lib/server/listeners/host.go
+++ b/lib/server/listeners/host.go
@@ -493,7 +493,7 @@ func (s *HostListener) Status(ctx context.Context, in *protocol.Reference) (ht *
 	}
 
 	// Data sync
-	xerr = hostInstance.Reload()
+	xerr = hostInstance.Reload(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}

--- a/lib/server/listeners/network.go
+++ b/lib/server/listeners/network.go
@@ -160,7 +160,7 @@ func (s *NetworkListener) Create(ctx context.Context, in *protocol.NetworkCreate
 	}
 
 	tracer.Trace("Network '%s' successfully created.", networkName)
-	return networkInstance.ToProtocol()
+	return networkInstance.ToProtocol(ctx)
 }
 
 // List existing networks
@@ -243,7 +243,7 @@ func (s *NetworkListener) Inspect(ctx context.Context, in *protocol.Reference) (
 		return nil, xerr
 	}
 
-	return networkInstance.ToProtocol()
+	return networkInstance.ToProtocol(ctx)
 }
 
 // Delete a network

--- a/lib/server/listeners/securitygroup.go
+++ b/lib/server/listeners/securitygroup.go
@@ -125,7 +125,7 @@ func (s *SecurityGroupListener) Create(ctx context.Context, in *protocol.Securit
 		return nil, xerr
 	}
 
-	return sgInstance.ToProtocol()
+	return sgInstance.ToProtocol(ctx)
 }
 
 // Clear calls the clear method to remove all rules from a security group
@@ -255,7 +255,7 @@ func (s *SecurityGroupListener) Inspect(ctx context.Context, in *protocol.Refere
 		return nil, xerr
 	}
 
-	return sgInstance.ToProtocol()
+	return sgInstance.ToProtocol(ctx)
 }
 
 // Delete a host
@@ -350,7 +350,7 @@ func (s *SecurityGroupListener) AddRule(ctx context.Context, in *protocol.Securi
 	}
 
 	tracer.Trace("Rule successfully added to security group %s", sgRefLabel)
-	return sgInstance.ToProtocol()
+	return sgInstance.ToProtocol(ctx)
 }
 
 // DeleteRule deletes a rule identified by id from a security group
@@ -399,7 +399,7 @@ func (s *SecurityGroupListener) DeleteRule(ctx context.Context, in *protocol.Sec
 	}
 
 	tracer.Trace("Rule successfully added to security group %s", refLabel)
-	return sgInstance.ToProtocol()
+	return sgInstance.ToProtocol(ctx)
 }
 
 // Sanitize checks if provider-side rules are coherent with registered ones in metadata

--- a/lib/server/resources/bucket.go
+++ b/lib/server/resources/bucket.go
@@ -33,6 +33,7 @@ type Bucket interface {
 	Metadata
 	data.Identifiable
 	observer.Observable
+	Consistent
 
 	Browse(ctx context.Context, callback func(bucket *abstract.ObjectStorageBucket) fail.Error) fail.Error
 	Create(ctx context.Context, name string) fail.Error

--- a/lib/server/resources/cluster.go
+++ b/lib/server/resources/cluster.go
@@ -52,13 +52,13 @@ type Cluster interface {
 	Delete(ctx context.Context, force bool) fail.Error                                                                                           // deletes the cluster (Delete is not used to not collision with metadata)
 	FindAvailableMaster(ctx context.Context) (Host, fail.Error)                                                                                  // returns ID of the first master available to execute order
 	FindAvailableNode(ctx context.Context) (Host, fail.Error)                                                                                    // returns node instance of the first node available to execute order
-	GetIdentity() (abstract.ClusterIdentity, fail.Error)                                                                                         // returns Cluster Identity
-	GetFlavor() (clusterflavor.Enum, fail.Error)                                                                                                 // returns the flavor of the cluster
-	GetComplexity() (clustercomplexity.Enum, fail.Error)                                                                                         // returns the complexity of the cluster
-	GetAdminPassword() (string, fail.Error)                                                                                                      // returns the password of the cluster admin account
-	GetKeyPair() (*abstract.KeyPair, fail.Error)                                                                                                 // returns the key pair used in the cluster
-	GetNetworkConfig() (*propertiesv3.ClusterNetwork, fail.Error)                                                                                // returns network configuration of the cluster
-	GetState() (clusterstate.Enum, fail.Error)                                                                                                   // returns the current state of the cluster
+	GetIdentity(ctx context.Context) (abstract.ClusterIdentity, fail.Error)                                                                      // returns Cluster Identity
+	GetFlavor(ctx context.Context) (clusterflavor.Enum, fail.Error)                                                                              // returns the flavor of the cluster
+	GetComplexity(ctx context.Context) (clustercomplexity.Enum, fail.Error)                                                                      // returns the complexity of the cluster
+	GetAdminPassword(ctx context.Context) (string, fail.Error)                                                                                   // returns the password of the cluster admin account
+	GetKeyPair(ctx context.Context) (*abstract.KeyPair, fail.Error)                                                                              // returns the key pair used in the cluster
+	GetNetworkConfig(ctx context.Context) (*propertiesv3.ClusterNetwork, fail.Error)                                                             // returns network configuration of the cluster
+	GetState(ctx context.Context) (clusterstate.Enum, fail.Error)                                                                                // returns the current state of the cluster
 	IsFeatureInstalled(ctx context.Context, name string) (found bool, ferr fail.Error)                                                           // tells if a feature is installed in Cluster using only metadata
 	ListEligibleFeatures(ctx context.Context) ([]Feature, fail.Error)                                                                            // returns the list of eligible features for the Cluster
 	ListInstalledFeatures(ctx context.Context) ([]Feature, fail.Error)                                                                           // returns the list of installed features on the Cluster
@@ -75,5 +75,5 @@ type Cluster interface {
 	Shrink(ctx context.Context, count uint) ([]*propertiesv3.ClusterNode, fail.Error)                                                            // reduce the size of the cluster of 'count' nodes (the last created)
 	Start(ctx context.Context) fail.Error                                                                                                        // starts the cluster
 	Stop(ctx context.Context) fail.Error                                                                                                         // stops the cluster
-	ToProtocol() (*protocol.ClusterResponse, fail.Error)
+	ToProtocol(ctx context.Context) (*protocol.ClusterResponse, fail.Error)
 }

--- a/lib/server/resources/cluster.go
+++ b/lib/server/resources/cluster.go
@@ -40,6 +40,7 @@ type Cluster interface {
 	Metadata
 	Targetable
 	observer.Observable
+	Consistent
 
 	AddFeature(ctx context.Context, name string, vars data.Map, settings FeatureSettings) (Results, fail.Error)                                  // adds feature on cluster
 	AddNodes(ctx context.Context, count uint, def abstract.HostSizingRequirements, parameters data.Map, keepOnFailure bool) ([]Host, fail.Error) // adds several nodes

--- a/lib/server/resources/feature.go
+++ b/lib/server/resources/feature.go
@@ -55,7 +55,7 @@ type Feature interface {
 	Dependencies(ctx context.Context) (map[string]struct{}, fail.Error)                             // returns the other features needed as requirements
 	ListParametersWithControl(ctx context.Context) []string                                         // returns a list of parameter containing version information
 	Remove(ctx context.Context, t Targetable, v data.Map, fs FeatureSettings) (Results, fail.Error) // uninstalls the feature from the target
-	ToProtocol() *protocol.FeatureResponse
+	ToProtocol(ctx context.Context) *protocol.FeatureResponse
 }
 
 // FeatureSettings are used to tune the feature

--- a/lib/server/resources/feature.go
+++ b/lib/server/resources/feature.go
@@ -33,13 +33,13 @@ import (
 type Targetable interface {
 	data.Identifiable
 
-	ComplementFeatureParameters(ctx context.Context, v data.Map) fail.Error        // adds parameters corresponding to the Target in preparation of feature installation
-	UnregisterFeature(f string) fail.Error                                         // unregisters a Feature from Target in metadata
-	InstalledFeatures() []string                                                   // returns a list of installed features
-	InstallMethods() (map[uint8]installmethod.Enum, fail.Error)                    // returns a list of installation methods usable on the target, ordered from upper to lower preference (1 = the highest preference)
-	RegisterFeature(f Feature, requiredBy Feature, clusterContext bool) fail.Error // registers a feature on target in metadata
-	Service() iaas.Service                                                         // returns the iaas.Service used by the target
-	TargetType() featuretargettype.Enum                                            // returns the type of the target
+	ComplementFeatureParameters(ctx context.Context, v data.Map) fail.Error                                // adds parameters corresponding to the Target in preparation of feature installation
+	UnregisterFeature(ctx context.Context, feat string) fail.Error                                         // unregisters a Feature from Target in metadata
+	InstalledFeatures(ctx context.Context) []string                                                        // returns a list of installed features
+	InstallMethods(ctx context.Context) (map[uint8]installmethod.Enum, fail.Error)                         // returns a list of installation methods usable on the target, ordered from upper to lower preference (1 = the highest preference)
+	RegisterFeature(ctx context.Context, feat Feature, requiredBy Feature, clusterContext bool) fail.Error // registers a feature on target in metadata
+	Service() iaas.Service                                                                                 // returns the iaas.Service used by the target
+	TargetType() featuretargettype.Enum                                                                    // returns the type of the target
 }
 
 // Feature defines the interface of feature
@@ -48,12 +48,12 @@ type Feature interface {
 	data.Identifiable
 
 	Add(ctx context.Context, t Targetable, v data.Map, fs FeatureSettings) (Results, fail.Error)    // installs the feature on the target
-	Applicable(Targetable) (bool, fail.Error)                                                       // tells if the feature is installable on the target
+	Applicable(ctx context.Context, tg Targetable) (bool, fail.Error)                               // tells if the feature is installable on the target
 	Check(ctx context.Context, t Targetable, v data.Map, fs FeatureSettings) (Results, fail.Error)  // check if feature is installed on target
-	GetDisplayFilename() string                                                                     // displays the filename of display (optionally adding '[embedded]' for embedded features)
-	GetFilename() string                                                                            // returns the filename of the feature
-	Dependencies() (map[string]struct{}, fail.Error)                                                // returns the other features needed as requirements
-	ListParametersWithControl() []string                                                            // returns a list of parameter containing version information
+	GetDisplayFilename(ctx context.Context) string                                                  // displays the filename of display (optionally adding '[embedded]' for embedded features)
+	GetFilename(ctx context.Context) string                                                         // returns the filename of the feature
+	Dependencies(ctx context.Context) (map[string]struct{}, fail.Error)                             // returns the other features needed as requirements
+	ListParametersWithControl(ctx context.Context) []string                                         // returns a list of parameter containing version information
 	Remove(ctx context.Context, t Targetable, v data.Map, fs FeatureSettings) (Results, fail.Error) // uninstalls the feature from the target
 	ToProtocol() *protocol.FeatureResponse
 }

--- a/lib/server/resources/host.go
+++ b/lib/server/resources/host.go
@@ -51,7 +51,7 @@ type Host interface {
 	ForceGetState(ctx context.Context) (hoststate.Enum, fail.Error)                                                                              // returns the real current state of the host, with error handling
 	GetAccessIP(ctx context.Context) (string, fail.Error)                                                                                        // returns the IP to reach the host, with error handling
 	GetDefaultSubnet(ctx context.Context) (Subnet, fail.Error)                                                                                   // returns the resources.Subnet instance corresponding to the default subnet of the host, with error handling
-	GetMounts() (*propertiesv1.HostMounts, fail.Error)                                                                                           // returns the mounts on the host
+	GetMounts(ctx context.Context) (*propertiesv1.HostMounts, fail.Error)                                                                        // returns the mounts on the host
 	GetPrivateIP(ctx context.Context) (string, fail.Error)                                                                                       // returns the IP address of the host on the default subnet, with error handling
 	GetPrivateIPOnSubnet(ctx context.Context, subnetID string) (string, fail.Error)                                                              // returns the IP address of the host on the requested subnet, with error handling
 	GetPublicIP(ctx context.Context) (string, fail.Error)                                                                                        // returns the public IP address of the host, with error handling
@@ -59,11 +59,11 @@ type Host interface {
 	GetShares(ctx context.Context) (*propertiesv1.HostShares, fail.Error)                                                                        // returns the shares hosted on the host
 	GetSSHConfig(ctx context.Context) (*system.SSHConfig, fail.Error)                                                                            // loads SSH configuration for host from metadata
 	GetState() (hoststate.Enum, fail.Error)                                                                                                      // returns the current state of the host, with error handling
-	GetVolumes() (*propertiesv1.HostVolumes, fail.Error)                                                                                         // returns the volumes attached to the host
-	IsClusterMember() (bool, fail.Error)                                                                                                         // returns true if the host is member of a cluster
-	IsFeatureInstalled(f string) (bool, fail.Error)                                                                                              // tells if a feature is installed on Host, using only metadata
+	GetVolumes(ctx context.Context) (*propertiesv1.HostVolumes, fail.Error)                                                                      // returns the volumes attached to the host
+	IsClusterMember(ctx context.Context) (bool, fail.Error)                                                                                      // returns true if the host is member of a cluster
+	IsFeatureInstalled(ctx context.Context, name string) (bool, fail.Error)                                                                      // tells if a feature is installed on Host, using only metadata
 	IsGateway() (bool, fail.Error)                                                                                                               // tells of  the host acts as a gateway
-	IsSingle() (bool, fail.Error)                                                                                                                // tells of  the host acts as a gateway
+	IsSingle(ctx context.Context) (bool, fail.Error)                                                                                             // tells of  the host acts as a gateway
 	ListEligibleFeatures(ctx context.Context) ([]Feature, fail.Error)                                                                            // returns the list of eligible features for the Cluster
 	ListInstalledFeatures(ctx context.Context) ([]Feature, fail.Error)                                                                           // returns the list of installed features on the Cluster
 	ListSecurityGroups(ctx context.Context, state securitygroupstate.Enum) ([]*propertiesv1.SecurityGroupBond, fail.Error)                       // returns a slice of properties.SecurityGroupBond corresponding to bound Security Group of the host

--- a/lib/server/resources/host.go
+++ b/lib/server/resources/host.go
@@ -52,11 +52,11 @@ type Host interface {
 	GetAccessIP(ctx context.Context) (string, fail.Error)                                                                                        // returns the IP to reach the host, with error handling
 	GetDefaultSubnet(ctx context.Context) (Subnet, fail.Error)                                                                                   // returns the resources.Subnet instance corresponding to the default subnet of the host, with error handling
 	GetMounts() (*propertiesv1.HostMounts, fail.Error)                                                                                           // returns the mounts on the host
-	GetPrivateIP(ctx context.Context) (ip string, err fail.Error)                                                                                // returns the IP address of the host on the default subnet, with error handling
-	GetPrivateIPOnSubnet(subnetID string) (ip string, err fail.Error)                                                                            // returns the IP address of the host on the requested subnet, with error handling
-	GetPublicIP(ctx context.Context) (ip string, err fail.Error)                                                                                 // returns the public IP address of the host, with error handling
+	GetPrivateIP(ctx context.Context) (string, fail.Error)                                                                                       // returns the IP address of the host on the default subnet, with error handling
+	GetPrivateIPOnSubnet(ctx context.Context, subnetID string) (string, fail.Error)                                                              // returns the IP address of the host on the requested subnet, with error handling
+	GetPublicIP(ctx context.Context) (string, fail.Error)                                                                                        // returns the public IP address of the host, with error handling
 	GetShare(ctx context.Context, shareRef string) (*propertiesv1.HostShare, fail.Error)                                                         // returns a clone of the propertiesv1.HostShare corresponding to share 'shareRef'
-	GetShares() (*propertiesv1.HostShares, fail.Error)                                                                                           // returns the shares hosted on the host
+	GetShares(ctx context.Context) (*propertiesv1.HostShares, fail.Error)                                                                        // returns the shares hosted on the host
 	GetSSHConfig(ctx context.Context) (*system.SSHConfig, fail.Error)                                                                            // loads SSH configuration for host from metadata
 	GetState() (hoststate.Enum, fail.Error)                                                                                                      // returns the current state of the host, with error handling
 	GetVolumes() (*propertiesv1.HostVolumes, fail.Error)                                                                                         // returns the volumes attached to the host
@@ -66,7 +66,7 @@ type Host interface {
 	IsSingle() (bool, fail.Error)                                                                                                                // tells of  the host acts as a gateway
 	ListEligibleFeatures(ctx context.Context) ([]Feature, fail.Error)                                                                            // returns the list of eligible features for the Cluster
 	ListInstalledFeatures(ctx context.Context) ([]Feature, fail.Error)                                                                           // returns the list of installed features on the Cluster
-	ListSecurityGroups(state securitygroupstate.Enum) ([]*propertiesv1.SecurityGroupBond, fail.Error)                                            // returns a slice of properties.SecurityGroupBond corresponding to bound Security Group of the host
+	ListSecurityGroups(ctx context.Context, state securitygroupstate.Enum) ([]*propertiesv1.SecurityGroupBond, fail.Error)                       // returns a slice of properties.SecurityGroupBond corresponding to bound Security Group of the host
 	Pull(ctx context.Context, target, source string, timeout time.Duration) (int, string, string, fail.Error)                                    // downloads a file from host
 	Push(ctx context.Context, source, target, owner, mode string, timeout time.Duration) (int, string, string, fail.Error)                       // uploads a file to host
 	PushStringToFile(ctx context.Context, content string, filename string) fail.Error                                                            // creates a file 'filename' on remote 'host' with the content 'content'

--- a/lib/server/resources/host.go
+++ b/lib/server/resources/host.go
@@ -55,7 +55,7 @@ type Host interface {
 	GetPrivateIP(ctx context.Context) (ip string, err fail.Error)                                                                                // returns the IP address of the host on the default subnet, with error handling
 	GetPrivateIPOnSubnet(subnetID string) (ip string, err fail.Error)                                                                            // returns the IP address of the host on the requested subnet, with error handling
 	GetPublicIP(ctx context.Context) (ip string, err fail.Error)                                                                                 // returns the public IP address of the host, with error handling
-	GetShare(shareRef string) (*propertiesv1.HostShare, fail.Error)                                                                              // returns a clone of the propertiesv1.HostShare corresponding to share 'shareRef'
+	GetShare(ctx context.Context, shareRef string) (*propertiesv1.HostShare, fail.Error)                                                         // returns a clone of the propertiesv1.HostShare corresponding to share 'shareRef'
 	GetShares() (*propertiesv1.HostShares, fail.Error)                                                                                           // returns the shares hosted on the host
 	GetSSHConfig(ctx context.Context) (*system.SSHConfig, fail.Error)                                                                            // loads SSH configuration for host from metadata
 	GetState() (hoststate.Enum, fail.Error)                                                                                                      // returns the current state of the host, with error handling

--- a/lib/server/resources/host.go
+++ b/lib/server/resources/host.go
@@ -40,6 +40,7 @@ type Host interface {
 	Metadata
 	Targetable
 	observer.Observable
+	Consistent
 
 	BindSecurityGroup(ctx context.Context, sg SecurityGroup, enable SecurityGroupActivation) fail.Error                                // Binds a security group to host
 	Browse(ctx context.Context, callback func(*abstract.HostCore) fail.Error) fail.Error                                               // ...

--- a/lib/server/resources/host.go
+++ b/lib/server/resources/host.go
@@ -58,11 +58,11 @@ type Host interface {
 	GetShare(ctx context.Context, shareRef string) (*propertiesv1.HostShare, fail.Error)                                                         // returns a clone of the propertiesv1.HostShare corresponding to share 'shareRef'
 	GetShares(ctx context.Context) (*propertiesv1.HostShares, fail.Error)                                                                        // returns the shares hosted on the host
 	GetSSHConfig(ctx context.Context) (*system.SSHConfig, fail.Error)                                                                            // loads SSH configuration for host from metadata
-	GetState() (hoststate.Enum, fail.Error)                                                                                                      // returns the current state of the host, with error handling
+	GetState(ctx context.Context) (hoststate.Enum, fail.Error)                                                                                   // returns the current state of the host, with error handling
 	GetVolumes(ctx context.Context) (*propertiesv1.HostVolumes, fail.Error)                                                                      // returns the volumes attached to the host
 	IsClusterMember(ctx context.Context) (bool, fail.Error)                                                                                      // returns true if the host is member of a cluster
 	IsFeatureInstalled(ctx context.Context, name string) (bool, fail.Error)                                                                      // tells if a feature is installed on Host, using only metadata
-	IsGateway() (bool, fail.Error)                                                                                                               // tells of  the host acts as a gateway
+	IsGateway(ctx context.Context) (bool, fail.Error)                                                                                            // tells of  the host acts as a gateway
 	IsSingle(ctx context.Context) (bool, fail.Error)                                                                                             // tells of  the host acts as a gateway
 	ListEligibleFeatures(ctx context.Context) ([]Feature, fail.Error)                                                                            // returns the list of eligible features for the Cluster
 	ListInstalledFeatures(ctx context.Context) ([]Feature, fail.Error)                                                                           // returns the list of installed features on the Cluster

--- a/lib/server/resources/metadata.go
+++ b/lib/server/resources/metadata.go
@@ -40,8 +40,8 @@ type Metadata interface {
 	Deserialize(ctx context.Context, buf []byte) fail.Error                                     // Transforms a slice of bytes in struct
 	Inspect(ctx context.Context, callback Callback) fail.Error                                  // protects the data for shared read with first reloading data from Object Storage
 	Review(ctx context.Context, callback Callback) fail.Error                                   // protects the data for shared read without reloading first (uses in-memory data); use with caution
-	Read(ref string) fail.Error                                                                 // reads the data from Object Storage using ref as id or name
-	ReadByID(id string) fail.Error                                                              // reads the data from Object Storage by id
+	Read(ctx context.Context, ref string) fail.Error                                            // reads the data from Object Storage using ref as id or name
+	ReadByID(ctx context.Context, id string) fail.Error                                         // reads the data from Object Storage by id
 	Reload(ctx context.Context) fail.Error                                                      // Reloads the metadata from the Object Storage, overriding what is in the object
 	Sdump(ctx context.Context) (string, fail.Error)
 	Service() iaas.Service // returns the iaas.Service used

--- a/lib/server/resources/metadata.go
+++ b/lib/server/resources/metadata.go
@@ -45,6 +45,10 @@ type Metadata interface {
 	Service() iaas.Service // returns the iaas.Service used
 }
 
+type Consistent interface {
+	Exists() (bool, fail.Error)
+}
+
 /*
 //go:generate gowrap gen -g -p github.com/CS-SI/SafeScale/v22/lib/server/resources -i RawMetadata -t ./microfallback.tmpl -o breakeven.go -l ""
 

--- a/lib/server/resources/metadata.go
+++ b/lib/server/resources/metadata.go
@@ -39,7 +39,7 @@ type Metadata interface {
 	BrowseFolder(callback func(buf []byte) fail.Error) fail.Error                               // walks through host folder and executes a callback for each entry
 	Deserialize(buf []byte) fail.Error                                                          // Transforms a slice of bytes in struct
 	Inspect(callback Callback) fail.Error                                                       // protects the data for shared read with first reloading data from Object Storage
-	Review(callback Callback) fail.Error                                                        // protects the data for shared read without reloading first (uses in-memory data); use with caution
+	Review(ctx context.Context, callback Callback) fail.Error                                   // protects the data for shared read without reloading first (uses in-memory data); use with caution
 	Read(ref string) fail.Error                                                                 // reads the data from Object Storage using ref as id or name
 	ReadByID(id string) fail.Error                                                              // reads the data from Object Storage by id
 	Reload(ctx context.Context) fail.Error                                                      // Reloads the metadata from the Object Storage, overriding what is in the object

--- a/lib/server/resources/metadata.go
+++ b/lib/server/resources/metadata.go
@@ -17,6 +17,8 @@
 package resources
 
 import (
+	"context"
+
 	"github.com/CS-SI/SafeScale/v22/lib/server/iaas"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/data"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/data/serialize"
@@ -33,14 +35,14 @@ type Callback = func(data.Clonable, *serialize.JSONProperties) fail.Error
 // Metadata contains the core functions of a persistent object
 type Metadata interface {
 	IsNull() bool
-	Alter(callback Callback, options ...data.ImmutableKeyValue) fail.Error // protects the data for exclusive write
-	BrowseFolder(callback func(buf []byte) fail.Error) fail.Error          // walks through host folder and executes a callback for each entry
-	Deserialize(buf []byte) fail.Error                                     // Transforms a slice of bytes in struct
-	Inspect(callback Callback) fail.Error                                  // protects the data for shared read with first reloading data from Object Storage
-	Review(callback Callback) fail.Error                                   // protects the data for shared read without reloading first (uses in-memory data); use with caution
-	Read(ref string) fail.Error                                            // reads the data from Object Storage using ref as id or name
-	ReadByID(id string) fail.Error                                         // reads the data from Object Storage by id
-	Reload() fail.Error                                                    // Reloads the metadata from the Object Storage, overriding what is in the object
+	Alter(ctx context.Context, callback Callback, options ...data.ImmutableKeyValue) fail.Error // protects the data for exclusive write
+	BrowseFolder(callback func(buf []byte) fail.Error) fail.Error                               // walks through host folder and executes a callback for each entry
+	Deserialize(buf []byte) fail.Error                                                          // Transforms a slice of bytes in struct
+	Inspect(callback Callback) fail.Error                                                       // protects the data for shared read with first reloading data from Object Storage
+	Review(callback Callback) fail.Error                                                        // protects the data for shared read without reloading first (uses in-memory data); use with caution
+	Read(ref string) fail.Error                                                                 // reads the data from Object Storage using ref as id or name
+	ReadByID(id string) fail.Error                                                              // reads the data from Object Storage by id
+	Reload() fail.Error                                                                         // Reloads the metadata from the Object Storage, overriding what is in the object
 	Sdump() (string, fail.Error)
 	Service() iaas.Service // returns the iaas.Service used
 }

--- a/lib/server/resources/metadata.go
+++ b/lib/server/resources/metadata.go
@@ -42,8 +42,8 @@ type Metadata interface {
 	Review(callback Callback) fail.Error                                                        // protects the data for shared read without reloading first (uses in-memory data); use with caution
 	Read(ref string) fail.Error                                                                 // reads the data from Object Storage using ref as id or name
 	ReadByID(id string) fail.Error                                                              // reads the data from Object Storage by id
-	Reload() fail.Error                                                                         // Reloads the metadata from the Object Storage, overriding what is in the object
-	Sdump() (string, fail.Error)
+	Reload(ctx context.Context) fail.Error                                                      // Reloads the metadata from the Object Storage, overriding what is in the object
+	Sdump(ctx context.Context) (string, fail.Error)
 	Service() iaas.Service // returns the iaas.Service used
 }
 

--- a/lib/server/resources/metadata.go
+++ b/lib/server/resources/metadata.go
@@ -37,8 +37,8 @@ type Metadata interface {
 	IsNull() bool
 	Alter(ctx context.Context, callback Callback, options ...data.ImmutableKeyValue) fail.Error // protects the data for exclusive write
 	BrowseFolder(callback func(buf []byte) fail.Error) fail.Error                               // walks through host folder and executes a callback for each entry
-	Deserialize(buf []byte) fail.Error                                                          // Transforms a slice of bytes in struct
-	Inspect(callback Callback) fail.Error                                                       // protects the data for shared read with first reloading data from Object Storage
+	Deserialize(ctx context.Context, buf []byte) fail.Error                                     // Transforms a slice of bytes in struct
+	Inspect(ctx context.Context, callback Callback) fail.Error                                  // protects the data for shared read with first reloading data from Object Storage
 	Review(ctx context.Context, callback Callback) fail.Error                                   // protects the data for shared read without reloading first (uses in-memory data); use with caution
 	Read(ref string) fail.Error                                                                 // reads the data from Object Storage using ref as id or name
 	ReadByID(id string) fail.Error                                                              // reads the data from Object Storage by id

--- a/lib/server/resources/metadata.go
+++ b/lib/server/resources/metadata.go
@@ -36,7 +36,7 @@ type Callback = func(data.Clonable, *serialize.JSONProperties) fail.Error
 type Metadata interface {
 	IsNull() bool
 	Alter(ctx context.Context, callback Callback, options ...data.ImmutableKeyValue) fail.Error // protects the data for exclusive write
-	BrowseFolder(callback func(buf []byte) fail.Error) fail.Error                               // walks through host folder and executes a callback for each entry
+	BrowseFolder(ctx context.Context, callback func(buf []byte) fail.Error) fail.Error          // walks through host folder and executes a callback for each entry
 	Deserialize(ctx context.Context, buf []byte) fail.Error                                     // Transforms a slice of bytes in struct
 	Inspect(ctx context.Context, callback Callback) fail.Error                                  // protects the data for shared read with first reloading data from Object Storage
 	Review(ctx context.Context, callback Callback) fail.Error                                   // protects the data for shared read without reloading first (uses in-memory data); use with caution

--- a/lib/server/resources/network.go
+++ b/lib/server/resources/network.go
@@ -34,6 +34,7 @@ type Network interface {
 	Metadata
 	data.Identifiable
 	observer.Observable
+	Consistent
 
 	AbandonSubnet(ctx context.Context, subnetID string) fail.Error                      // used to detach a Subnet from the Network
 	AdoptSubnet(ctx context.Context, subnet Subnet) fail.Error                          // used to attach a Subnet to the Network

--- a/lib/server/resources/network.go
+++ b/lib/server/resources/network.go
@@ -43,5 +43,5 @@ type Network interface {
 	Delete(ctx context.Context) fail.Error
 	Import(ctx context.Context, ref string) fail.Error
 	InspectSubnet(ctx context.Context, subnetRef string) (Subnet, fail.Error) // returns the Subnet instance corresponding to Subnet reference (ID or name) provided (if Subnet is attached to the Network)
-	ToProtocol() (*protocol.Network, fail.Error)                              // converts the network to protobuf message
+	ToProtocol(ctx context.Context) (*protocol.Network, fail.Error)           // converts the network to protobuf message
 }

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -388,7 +388,7 @@ func (instance *bucket) Delete(ctx context.Context) (ferr fail.Error) {
 	defer instance.lock.Unlock()
 
 	// -- check Bucket is not still mounted
-	xerr = instance.Review(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Review(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(bucketproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.BucketMounts)
 			if !ok {
@@ -466,7 +466,7 @@ func (instance *bucket) Mount(ctx context.Context, hostName, path string) (ferr 
 	}
 
 	// -- check if Bucket is already mounted on any Host (only one Mount by Bucket allowed by design, to mitigate sync issues induced by Object Storage)
-	xerr = instance.Review(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Review(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(bucketproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.BucketMounts)
 			if !ok {
@@ -559,7 +559,7 @@ func (instance *bucket) Mount(ctx context.Context, hostName, path string) (ferr 
 	}
 
 	// -- update metadata of Bucket
-	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(bucketproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.BucketMounts)
 			if !ok {
@@ -681,7 +681,7 @@ func (instance *bucket) Unmount(ctx context.Context, hostName string) (ferr fail
 		return xerr
 	}
 
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(bucketproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.BucketMounts)
 			if !ok {
@@ -701,7 +701,7 @@ func (instance *bucket) ToProtocol(ctx context.Context) (*protocol.BucketRespons
 		Name: instance.GetName(),
 	}
 
-	xerr := instance.Review(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(bucketproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.BucketMounts)
 			if !ok {

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -110,8 +110,7 @@ func onBucketCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.
 		return nil, innerXErr
 	}
 
-	// TODO: core.ReadByID() does not check communication failure, side effect of limitations of Stow (waiting for stow replacement by rclone)
-	if innerXErr = bucketInstance.Read(ref); innerXErr != nil {
+	if innerXErr = bucketInstance.Read(ctx, ref); innerXErr != nil {
 		return nil, innerXErr
 	}
 

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -559,7 +559,7 @@ func (instance *bucket) Mount(ctx context.Context, hostName, path string) (ferr 
 	}
 
 	// -- update metadata of Bucket
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(bucketproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.BucketMounts)
 			if !ok {
@@ -576,7 +576,7 @@ func (instance *bucket) Mount(ctx context.Context, hostName, path string) (ferr 
 	}
 
 	// -- update metadata of Host
-	return hostInstance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return hostInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.HostMounts)
 			if !ok {
@@ -666,7 +666,7 @@ func (instance *bucket) Unmount(ctx context.Context, hostName string) (ferr fail
 		}
 	}
 
-	xerr = hostInstance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = hostInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.HostMounts)
 			if !ok {
@@ -681,7 +681,7 @@ func (instance *bucket) Unmount(ctx context.Context, hostName string) (ferr fail
 		return xerr
 	}
 
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(bucketproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			mountsV1, ok := clonable.(*propertiesv1.BucketMounts)
 			if !ok {

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -630,7 +630,7 @@ func (instance *bucket) Unmount(ctx context.Context, hostName string) (ferr fail
 	var mountPoint string
 	bucketName := instance.GetName()
 
-	mounts, xerr := hostInstance.GetMounts()
+	mounts, xerr := hostInstance.GetMounts(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -188,21 +188,19 @@ func (instance *bucket) Browse(
 	instance.lock.RLock()
 	defer instance.lock.RUnlock()
 
-	return instance.MetadataCore.BrowseFolder(
-		func(buf []byte) (innerXErr fail.Error) {
-			if task.Aborted() {
-				return fail.AbortedError(nil, "aborted")
-			}
+	return instance.MetadataCore.BrowseFolder(ctx, func(buf []byte) (innerXErr fail.Error) {
+		if task.Aborted() {
+			return fail.AbortedError(nil, "aborted")
+		}
 
-			ab := abstract.NewObjectStorageBucket()
-			var inErr fail.Error
-			if inErr = ab.Deserialize(buf); inErr != nil {
-				return inErr
-			}
+		ab := abstract.NewObjectStorageBucket()
+		var inErr fail.Error
+		if inErr = ab.Deserialize(buf); inErr != nil {
+			return inErr
+		}
 
-			return callback(ab)
-		},
-	)
+		return callback(ab)
+	})
 }
 
 // GetHost ...

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -228,7 +228,7 @@ func (instance *bucket) GetHost(ctx context.Context) (_ string, ferr fail.Error)
 	defer instance.lock.RUnlock()
 
 	var res string
-	xerr = instance.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		ab, ok := clonable.(*abstract.ObjectStorageBucket)
 		if !ok {
 			return fail.InconsistentError("'*abstract.ObjectStorageBucket' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -268,7 +268,7 @@ func (instance *bucket) GetMountPoint(ctx context.Context) (string, fail.Error) 
 	defer instance.lock.RUnlock()
 
 	var res string
-	xerr = instance.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		ab, ok := clonable.(*abstract.ObjectStorageBucket)
 		if !ok {
 			return fail.InconsistentError("'*abstract.ObjectStorageBucket' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -80,7 +80,7 @@ func LoadBucket(ctx context.Context, svc iaas.Service, name string) (b resources
 		return nil, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onBucketCacheMiss(svc, name) }
+	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onBucketCacheMiss(ctx, svc, name) }
 	anon, xerr := cacheMissLoader()
 	if xerr != nil {
 		return nil, xerr
@@ -99,7 +99,7 @@ func LoadBucket(ctx context.Context, svc iaas.Service, name string) (b resources
 	return b, nil
 }
 
-func onBucketCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
+func onBucketCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
 	bucketInstance, innerXErr := NewBucket(svc)
 	if innerXErr != nil {
 		return nil, innerXErr
@@ -115,7 +115,7 @@ func onBucketCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Er
 		return nil, innerXErr
 	}
 
-	if strings.Compare(fail.IgnoreError(bucketInstance.Sdump()).(string), fail.IgnoreError(blank.Sdump()).(string)) == 0 {
+	if strings.Compare(fail.IgnoreError(bucketInstance.Sdump(ctx)).(string), fail.IgnoreError(blank.Sdump(ctx)).(string)) == 0 {
 		return nil, fail.NotFoundError("bucket with ref '%s' does NOT exist", ref)
 	}
 

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -127,6 +127,10 @@ func (instance *bucket) IsNull() bool {
 	return instance == nil || instance.MetadataCore == nil || valid.IsNil(instance.MetadataCore)
 }
 
+func (instance *bucket) Exists() (bool, fail.Error) {
+	return true, nil
+}
+
 // carry ...
 func (instance *bucket) carry(ctx context.Context, clonable data.Clonable) (ferr fail.Error) {
 	if instance == nil {

--- a/lib/server/resources/operations/cluster.go
+++ b/lib/server/resources/operations/cluster.go
@@ -201,7 +201,7 @@ func onClusterCacheMiss(ctx context.Context, svc iaas.Service, name string) (dat
 		return nil, xerr
 	}
 
-	flavor, xerr := clusterInstance.GetFlavor()
+	flavor, xerr := clusterInstance.GetFlavor(nil)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -418,7 +418,7 @@ func (instance *Cluster) Browse(ctx context.Context, callback func(*abstract.Clu
 }
 
 // GetIdentity returns the identity of the Cluster
-func (instance *Cluster) GetIdentity() (clusterIdentity abstract.ClusterIdentity, ferr fail.Error) {
+func (instance *Cluster) GetIdentity(ctx context.Context) (clusterIdentity abstract.ClusterIdentity, ferr fail.Error) {
 	if valid.IsNil(instance) {
 		return abstract.ClusterIdentity{}, fail.InvalidInstanceError()
 	}
@@ -430,7 +430,7 @@ func (instance *Cluster) GetIdentity() (clusterIdentity abstract.ClusterIdentity
 }
 
 // GetFlavor returns the flavor of the Cluster
-func (instance *Cluster) GetFlavor() (flavor clusterflavor.Enum, ferr fail.Error) {
+func (instance *Cluster) GetFlavor(context.Context) (flavor clusterflavor.Enum, ferr fail.Error) {
 	if valid.IsNil(instance) {
 		return 0, fail.InvalidInstanceError()
 	}
@@ -445,7 +445,7 @@ func (instance *Cluster) GetFlavor() (flavor clusterflavor.Enum, ferr fail.Error
 }
 
 // GetComplexity returns the complexity of the Cluster
-func (instance *Cluster) GetComplexity() (_ clustercomplexity.Enum, ferr fail.Error) {
+func (instance *Cluster) GetComplexity(context.Context) (_ clustercomplexity.Enum, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if valid.IsNil(instance) {
@@ -460,7 +460,7 @@ func (instance *Cluster) GetComplexity() (_ clustercomplexity.Enum, ferr fail.Er
 
 // GetAdminPassword returns the password of the Cluster admin account
 // satisfies interface Cluster.Controller
-func (instance *Cluster) GetAdminPassword() (adminPassword string, ferr fail.Error) {
+func (instance *Cluster) GetAdminPassword(context.Context) (adminPassword string, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if valid.IsNil(instance) {
@@ -470,7 +470,7 @@ func (instance *Cluster) GetAdminPassword() (adminPassword string, ferr fail.Err
 	tracer := debug.NewTracer(nil, tracing.ShouldTrace("resources.cluster")).Entering()
 	defer tracer.Exiting()
 
-	aci, xerr := instance.GetIdentity()
+	aci, xerr := instance.GetIdentity(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return "", xerr
@@ -479,14 +479,14 @@ func (instance *Cluster) GetAdminPassword() (adminPassword string, ferr fail.Err
 }
 
 // GetKeyPair returns the key pair used in the Cluster
-func (instance *Cluster) GetKeyPair() (keyPair *abstract.KeyPair, ferr fail.Error) {
+func (instance *Cluster) GetKeyPair(context.Context) (keyPair *abstract.KeyPair, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
 		return nil, fail.InvalidInstanceError()
 	}
 
-	aci, xerr := instance.GetIdentity()
+	aci, xerr := instance.GetIdentity(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr
@@ -496,7 +496,7 @@ func (instance *Cluster) GetKeyPair() (keyPair *abstract.KeyPair, ferr fail.Erro
 }
 
 // GetNetworkConfig returns subnet configuration of the Cluster
-func (instance *Cluster) GetNetworkConfig() (config *propertiesv3.ClusterNetwork, ferr fail.Error) {
+func (instance *Cluster) GetNetworkConfig(context.Context) (config *propertiesv3.ClusterNetwork, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -1033,7 +1033,7 @@ func (instance *Cluster) Stop(ctx context.Context) (ferr fail.Error) {
 
 // GetState returns the current state of the Cluster
 // Uses the "maker" ForceGetState
-func (instance *Cluster) GetState() (state clusterstate.Enum, ferr fail.Error) {
+func (instance *Cluster) GetState(context.Context) (state clusterstate.Enum, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	state = clusterstate.Unknown
@@ -3137,7 +3137,7 @@ func (instance *Cluster) deleteHosts(task concurrency.Task, hosts []resources.Ho
 }
 
 // ToProtocol converts instance to protocol.ClusterResponse message
-func (instance *Cluster) ToProtocol() (_ *protocol.ClusterResponse, ferr fail.Error) {
+func (instance *Cluster) ToProtocol(context.Context) (_ *protocol.ClusterResponse, ferr fail.Error) {
 	if instance == nil || valid.IsNil(instance) {
 		return nil, fail.InvalidInstanceError()
 	}

--- a/lib/server/resources/operations/cluster.go
+++ b/lib/server/resources/operations/cluster.go
@@ -197,7 +197,7 @@ func onClusterCacheMiss(ctx context.Context, svc iaas.Service, name string) (dat
 		return nil, xerr
 	}
 
-	if xerr = clusterInstance.Read(name); xerr != nil {
+	if xerr = clusterInstance.Read(ctx, name); xerr != nil {
 		return nil, xerr
 	}
 

--- a/lib/server/resources/operations/cluster.go
+++ b/lib/server/resources/operations/cluster.go
@@ -613,7 +613,7 @@ func (instance *Cluster) Start(ctx context.Context) (ferr fail.Error) {
 	}
 
 	// First mark Cluster to be in state Starting
-	xerr = instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(clusterproperty.StateV1, func(clonable data.Clonable) fail.Error {
 			stateV1, ok := clonable.(*propertiesv1.ClusterState)
 			if !ok {
@@ -636,7 +636,7 @@ func (instance *Cluster) Start(ctx context.Context) (ferr fail.Error) {
 	)
 
 	// Then start it and mark it as NOMINAL on success
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		innerXErr := props.Inspect(clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
 			nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
 			if !ok {
@@ -775,7 +775,7 @@ func (instance *Cluster) Start(ctx context.Context) (ferr fail.Error) {
 	if len(problems) > 0 {
 		// Mark Cluster as state Degraded
 		outerr := fail.NewErrorList(problems)
-		xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+		xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 			return props.Alter(clusterproperty.StateV1, func(clonable data.Clonable) fail.Error {
 				stateV1, ok := clonable.(*propertiesv1.ClusterState)
 				if !ok {
@@ -792,7 +792,7 @@ func (instance *Cluster) Start(ctx context.Context) (ferr fail.Error) {
 		return outerr
 	}
 
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(clusterproperty.StateV1, func(clonable data.Clonable) fail.Error {
 			stateV1, ok := clonable.(*propertiesv1.ClusterState)
 			if !ok {
@@ -892,7 +892,7 @@ func (instance *Cluster) Stop(ctx context.Context) (ferr fail.Error) {
 	}
 
 	// First mark Cluster to be in state Stopping
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(clusterproperty.StateV1, func(clonable data.Clonable) fail.Error {
 			stateV1, ok := clonable.(*propertiesv1.ClusterState)
 			if !ok {
@@ -913,7 +913,7 @@ func (instance *Cluster) Stop(ctx context.Context) (ferr fail.Error) {
 	}
 
 	// Then stop it and mark it as STOPPED on success
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var (
 			nodes                         []string
 			masters                       []string
@@ -1967,7 +1967,7 @@ func (instance *Cluster) deleteMaster(ctx context.Context, host resources.Host) 
 	}
 
 	var master *propertiesv3.ClusterNode
-	xerr = instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
 			// Removes master from Cluster properties
 			nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
@@ -2004,7 +2004,7 @@ func (instance *Cluster) deleteMaster(ctx context.Context, host resources.Host) 
 	defer func() {
 		ferr = debug.InjectPlannedFail(ferr)
 		if ferr != nil {
-			derr := instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			derr := instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Alter(clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
 					nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
 					if !ok {
@@ -2061,7 +2061,7 @@ func (instance *Cluster) deleteNode(ctx context.Context, node *propertiesv3.Clus
 	}
 
 	// Identify the node to delete and remove it preventively from metadata
-	xerr = instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
 			nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
 			if !ok {
@@ -2092,7 +2092,7 @@ func (instance *Cluster) deleteNode(ctx context.Context, node *propertiesv3.Clus
 	defer func() {
 		ferr = debug.InjectPlannedFail(ferr)
 		if ferr != nil {
-			derr := instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			derr := instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Alter(clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
 					nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
 					if !ok {
@@ -2212,24 +2212,22 @@ func (instance *Cluster) delete(ctx context.Context) (ferr fail.Error) {
 	defer func() {
 		ferr = debug.InjectPlannedFail(ferr)
 		if ferr != nil {
-			derr := instance.Alter(
-				func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
-					return props.Alter(
-						clusterproperty.StateV1, func(clonable data.Clonable) fail.Error {
-							stateV1, ok := clonable.(*propertiesv1.ClusterState)
-							if !ok {
-								return fail.InconsistentError(
-									"'*propertiesv1.ClusterState' expected, '%s' provided",
-									reflect.TypeOf(clonable).String(),
-								)
-							}
+			derr := instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+				return props.Alter(
+					clusterproperty.StateV1, func(clonable data.Clonable) fail.Error {
+						stateV1, ok := clonable.(*propertiesv1.ClusterState)
+						if !ok {
+							return fail.InconsistentError(
+								"'*propertiesv1.ClusterState' expected, '%s' provided",
+								reflect.TypeOf(clonable).String(),
+							)
+						}
 
-							stateV1.State = clusterstate.Degraded
-							return nil
-						},
-					)
-				},
-			)
+						stateV1.State = clusterstate.Degraded
+						return nil
+					},
+				)
+			})
 			if derr != nil {
 				_ = ferr.AddConsequence(
 					fail.Wrap(
@@ -2245,7 +2243,7 @@ func (instance *Cluster) delete(ctx context.Context) (ferr fail.Error) {
 		nodes, masters []uint
 	)
 	// Mark the Cluster as Removed and get nodes from properties
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		// Updates Cluster state to mark Cluster as Removing
 		innerXErr := props.Alter(
 			clusterproperty.StateV1, func(clonable data.Clonable) fail.Error {
@@ -2372,7 +2370,7 @@ func (instance *Cluster) delete(ctx context.Context) (ferr fail.Error) {
 	}
 
 	// From here, make sure there is nothing in nodesV3.ByNumericalID; if there is something, delete all the remaining
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
 			nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
 			if !ok {
@@ -3071,29 +3069,27 @@ func (instance *Cluster) buildHostname(core string, nodeType clusternodetype.Enu
 	defer fail.OnPanic(&ferr)
 
 	var index int
-	xerr := instance.Alter(
-		func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
-			return props.Alter(
-				clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
-					nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
-					if !ok {
-						return fail.InconsistentError(
-							"'*propertiesv3.ClusterNodes' expected, '%s' provided", reflect.TypeOf(clonable).String(),
-						)
-					}
-					switch nodeType {
-					case clusternodetype.Node:
-						nodesV3.PrivateLastIndex++
-						index = nodesV3.PrivateLastIndex
-					case clusternodetype.Master:
-						nodesV3.MasterLastIndex++
-						index = nodesV3.MasterLastIndex
-					}
-					return nil
-				},
-			)
-		},
-	)
+	xerr := instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+		return props.Alter(
+			clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
+				nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
+				if !ok {
+					return fail.InconsistentError(
+						"'*propertiesv3.ClusterNodes' expected, '%s' provided", reflect.TypeOf(clonable).String(),
+					)
+				}
+				switch nodeType {
+				case clusternodetype.Node:
+					nodesV3.PrivateLastIndex++
+					index = nodesV3.PrivateLastIndex
+				case clusternodetype.Master:
+					nodesV3.MasterLastIndex++
+					index = nodesV3.MasterLastIndex
+				}
+				return nil
+			},
+		)
+	})
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return "", xerr
@@ -3318,41 +3314,39 @@ func (instance *Cluster) Shrink(ctx context.Context, count uint) (_ []*propertie
 		errors       []error
 		toRemove     []uint
 	)
-	xerr = instance.Alter(
-		func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
-			return props.Alter(
-				clusterproperty.NodesV3, func(clonable data.Clonable) (innerXErr fail.Error) {
-					nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
-					if !ok {
-						return fail.InconsistentError(
-							"'*propertiesv3.ClusterNodes' expected, '%s' provided", reflect.TypeOf(clonable).String(),
-						)
-					}
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+		return props.Alter(
+			clusterproperty.NodesV3, func(clonable data.Clonable) (innerXErr fail.Error) {
+				nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
+				if !ok {
+					return fail.InconsistentError(
+						"'*propertiesv3.ClusterNodes' expected, '%s' provided", reflect.TypeOf(clonable).String(),
+					)
+				}
 
-					length := uint(len(nodesV3.PrivateNodes))
-					if length < count {
-						return fail.InvalidRequestError(
-							"cannot shrink by %d node%s, only %d node%s available", count, strprocess.Plural(count),
-							length, strprocess.Plural(length),
-						)
-					}
+				length := uint(len(nodesV3.PrivateNodes))
+				if length < count {
+					return fail.InvalidRequestError(
+						"cannot shrink by %d node%s, only %d node%s available", count, strprocess.Plural(count),
+						length, strprocess.Plural(length),
+					)
+				}
 
-					first := length - count
-					toRemove = nodesV3.PrivateNodes[first:]
-					nodesV3.PrivateNodes = nodesV3.PrivateNodes[:first]
-					for _, v := range toRemove {
-						if node, ok := nodesV3.ByNumericalID[v]; ok {
-							removedNodes = append(removedNodes, node)
-							delete(nodesV3.ByNumericalID, v)
-							delete(nodesV3.PrivateNodeByID, node.ID)
-							delete(nodesV3.PrivateNodeByName, node.Name)
-						}
+				first := length - count
+				toRemove = nodesV3.PrivateNodes[first:]
+				nodesV3.PrivateNodes = nodesV3.PrivateNodes[:first]
+				for _, v := range toRemove {
+					if node, ok := nodesV3.ByNumericalID[v]; ok {
+						removedNodes = append(removedNodes, node)
+						delete(nodesV3.ByNumericalID, v)
+						delete(nodesV3.PrivateNodeByID, node.ID)
+						delete(nodesV3.PrivateNodeByName, node.Name)
 					}
-					return nil
-				},
-			)
-		},
-	)
+				}
+				return nil
+			},
+		)
+	})
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return emptySlice, nil
@@ -3361,29 +3355,27 @@ func (instance *Cluster) Shrink(ctx context.Context, count uint) (_ []*propertie
 	defer func() {
 		ferr = debug.InjectPlannedFail(ferr)
 		if ferr != nil {
-			derr := instance.Alter(
-				func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
-					return props.Alter(
-						clusterproperty.NodesV3, func(clonable data.Clonable) (innerXErr fail.Error) {
-							nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
-							if !ok {
-								return fail.InconsistentError(
-									"'*propertiesv3.ClusterNodes' expected, '%s' provided",
-									reflect.TypeOf(clonable).String(),
-								)
-							}
+			derr := instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+				return props.Alter(
+					clusterproperty.NodesV3, func(clonable data.Clonable) (innerXErr fail.Error) {
+						nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
+						if !ok {
+							return fail.InconsistentError(
+								"'*propertiesv3.ClusterNodes' expected, '%s' provided",
+								reflect.TypeOf(clonable).String(),
+							)
+						}
 
-							nodesV3.PrivateNodes = append(nodesV3.PrivateNodes, toRemove...)
-							for _, v := range removedNodes {
-								nodesV3.ByNumericalID[v.NumericalID] = v
-								nodesV3.PrivateNodeByName[v.Name] = v.NumericalID
-								nodesV3.PrivateNodeByID[v.ID] = v.NumericalID
-							}
-							return nil
-						},
-					)
-				},
-			)
+						nodesV3.PrivateNodes = append(nodesV3.PrivateNodes, toRemove...)
+						for _, v := range removedNodes {
+							nodesV3.ByNumericalID[v.NumericalID] = v
+							nodesV3.PrivateNodeByName[v.Name] = v.NumericalID
+							nodesV3.PrivateNodeByID[v.ID] = v.NumericalID
+						}
+						return nil
+					},
+				)
+			})
 			if derr != nil {
 				_ = ferr.AddConsequence(
 					fail.Wrap(

--- a/lib/server/resources/operations/cluster.go
+++ b/lib/server/resources/operations/cluster.go
@@ -114,6 +114,10 @@ func NewCluster(ctx context.Context, svc iaas.Service) (_ *Cluster, ferr fail.Er
 	return instance, nil
 }
 
+func (instance *Cluster) Exists() (bool, fail.Error) {
+	return true, nil
+}
+
 // StartRandomDelayGenerator starts a Task to generate random delays, read from instance.randomDelayCh
 func (instance *Cluster) startRandomDelayGenerator(ctx context.Context, min, max int) fail.Error {
 	chint := make(chan int)

--- a/lib/server/resources/operations/cluster.go
+++ b/lib/server/resources/operations/cluster.go
@@ -399,22 +399,20 @@ func (instance *Cluster) Browse(ctx context.Context, callback func(*abstract.Clu
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	return instance.MetadataCore.BrowseFolder(
-		func(buf []byte) fail.Error {
-			aci := abstract.NewClusterIdentity()
-			xerr := aci.Deserialize(buf)
-			xerr = debug.InjectPlannedFail(xerr)
-			if xerr != nil {
-				return xerr
-			}
+	return instance.MetadataCore.BrowseFolder(ctx, func(buf []byte) fail.Error {
+		aci := abstract.NewClusterIdentity()
+		xerr := aci.Deserialize(buf)
+		xerr = debug.InjectPlannedFail(xerr)
+		if xerr != nil {
+			return xerr
+		}
 
-			if task.Aborted() {
-				return fail.AbortedError(nil, "aborted")
-			}
+		if task.Aborted() {
+			return fail.AbortedError(nil, "aborted")
+		}
 
-			return callback(aci)
-		},
-	)
+		return callback(aci)
+	})
 }
 
 // GetIdentity returns the identity of the Cluster

--- a/lib/server/resources/operations/cluster.go
+++ b/lib/server/resources/operations/cluster.go
@@ -327,14 +327,14 @@ func (instance *Cluster) Create(ctx context.Context, req abstract.ClusterRequest
 	return nil
 }
 
-func (instance *Cluster) Sdump() (_ string, ferr fail.Error) {
+func (instance *Cluster) Sdump(context.Context) (_ string, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
 		return "", fail.InvalidInstanceError()
 	}
 
-	dumped, _ := instance.MetadataCore.Sdump()
+	dumped, _ := instance.MetadataCore.Sdump(nil)
 	return dumped, nil
 }
 

--- a/lib/server/resources/operations/cluster.go
+++ b/lib/server/resources/operations/cluster.go
@@ -201,7 +201,7 @@ func onClusterCacheMiss(ctx context.Context, svc iaas.Service, name string) (dat
 		return nil, xerr
 	}
 
-	flavor, xerr := clusterInstance.GetFlavor(nil)
+	flavor, xerr := clusterInstance.GetFlavor(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -468,7 +468,7 @@ func (instance *Cluster) GetAdminPassword(ctx context.Context) (adminPassword st
 	tracer := debug.NewTracer(ctx, tracing.ShouldTrace("resources.cluster")).Entering()
 	defer tracer.Exiting()
 
-	aci, xerr := instance.GetIdentity(nil)
+	aci, xerr := instance.GetIdentity(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return "", xerr
@@ -484,7 +484,7 @@ func (instance *Cluster) GetKeyPair(ctx context.Context) (keyPair *abstract.KeyP
 		return nil, fail.InvalidInstanceError()
 	}
 
-	aci, xerr := instance.GetIdentity(nil)
+	aci, xerr := instance.GetIdentity(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr

--- a/lib/server/resources/operations/clusterinstall.go
+++ b/lib/server/resources/operations/clusterinstall.go
@@ -250,7 +250,7 @@ func (instance *Cluster) RegisterFeature(ctx context.Context, feat resources.Fea
 		return fail.InvalidParameterError("feat", "cannot be null value of 'resources.Feature'")
 	}
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(clusterproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.ClusterFeatures)
 			if !ok {
@@ -290,7 +290,7 @@ func (instance *Cluster) UnregisterFeature(ctx context.Context, feat string) (fe
 		return fail.InvalidParameterError("feat", "cannot be empty string")
 	}
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(clusterproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.ClusterFeatures)
 			if !ok {

--- a/lib/server/resources/operations/clusterinstall.go
+++ b/lib/server/resources/operations/clusterinstall.go
@@ -130,7 +130,7 @@ func (instance *Cluster) ComplementFeatureParameters(ctx context.Context, v data
 			v["Username"] = abstract.DefaultUser
 		}
 	}
-	networkCfg, xerr := instance.GetNetworkConfig()
+	networkCfg, xerr := instance.GetNetworkConfig(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr
@@ -579,7 +579,7 @@ func (instance *Cluster) installNodeRequirements(ctx context.Context, nodeType c
 	defer fail.OnPanic(&ferr)
 	var xerr fail.Error
 
-	netCfg, xerr := instance.GetNetworkConfig()
+	netCfg, xerr := instance.GetNetworkConfig(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr

--- a/lib/server/resources/operations/clusterinstall.go
+++ b/lib/server/resources/operations/clusterinstall.go
@@ -130,7 +130,7 @@ func (instance *Cluster) ComplementFeatureParameters(ctx context.Context, v data
 			v["Username"] = abstract.DefaultUser
 		}
 	}
-	networkCfg, xerr := instance.GetNetworkConfig(nil)
+	networkCfg, xerr := instance.GetNetworkConfig(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr
@@ -361,7 +361,7 @@ func (instance *Cluster) ListInstalledFeatures(ctx context.Context) (_ []resourc
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	list := instance.InstalledFeatures(nil)
+	list := instance.InstalledFeatures(ctx)
 	// var list map[string]*propertiesv1.ClusterInstalledFeature
 	// xerr := instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 	// 	return props.Inspect(clusterproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
@@ -579,7 +579,7 @@ func (instance *Cluster) installNodeRequirements(ctx context.Context, nodeType c
 	defer fail.OnPanic(&ferr)
 	var xerr fail.Error
 
-	netCfg, xerr := instance.GetNetworkConfig(nil)
+	netCfg, xerr := instance.GetNetworkConfig(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr

--- a/lib/server/resources/operations/clusterinstall.go
+++ b/lib/server/resources/operations/clusterinstall.go
@@ -151,7 +151,7 @@ func (instance *Cluster) ComplementFeatureParameters(ctx context.Context, v data
 	v["CIDR"] = networkCfg.CIDR
 
 	var controlPlaneV1 *propertiesv1.ClusterControlplane
-	xerr = instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(clusterproperty.ControlPlaneV1, func(clonable data.Clonable) fail.Error {
 			var ok bool
 			controlPlaneV1, ok = clonable.(*propertiesv1.ClusterControlplane)
@@ -846,7 +846,7 @@ func (instance *Cluster) installRemoteDesktop(ctx context.Context, params data.M
 	}
 
 	disabled := false
-	xerr = instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(clusterproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.ClusterFeatures)
 			if !ok {
@@ -911,7 +911,7 @@ func (instance *Cluster) installAnsible(ctx context.Context, params data.Map) (f
 	}
 
 	disabled := false
-	xerr = instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(clusterproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.ClusterFeatures)
 			if !ok {

--- a/lib/server/resources/operations/clustertasks.go
+++ b/lib/server/resources/operations/clustertasks.go
@@ -1840,7 +1840,7 @@ func (instance *Cluster) taskCreateMaster(task concurrency.Task, params concurre
 		return nil, fail.AbortedError(lerr, "parent task killed")
 	}
 
-	netCfg, xerr := instance.GetNetworkConfig()
+	netCfg, xerr := instance.GetNetworkConfig(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr
@@ -2411,7 +2411,7 @@ func (instance *Cluster) taskCreateNode(task concurrency.Task, params concurrenc
 		}
 	}()
 
-	netCfg, xerr := instance.GetNetworkConfig()
+	netCfg, xerr := instance.GetNetworkConfig(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr

--- a/lib/server/resources/operations/clustertasks.go
+++ b/lib/server/resources/operations/clustertasks.go
@@ -1840,7 +1840,7 @@ func (instance *Cluster) taskCreateMaster(task concurrency.Task, params concurre
 		return nil, fail.AbortedError(lerr, "parent task killed")
 	}
 
-	netCfg, xerr := instance.GetNetworkConfig(nil)
+	netCfg, xerr := instance.GetNetworkConfig(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr
@@ -2407,7 +2407,7 @@ func (instance *Cluster) taskCreateNode(task concurrency.Task, params concurrenc
 		}
 	}()
 
-	netCfg, xerr := instance.GetNetworkConfig(nil)
+	netCfg, xerr := instance.GetNetworkConfig(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr

--- a/lib/server/resources/operations/clustertasks.go
+++ b/lib/server/resources/operations/clustertasks.go
@@ -216,7 +216,7 @@ func (instance *Cluster) taskCreateCluster(task concurrency.Task, params concurr
 
 			logrus.Debugf("Cleaning up on failure, deleting Hosts...")
 			var list map[uint]*propertiesv3.ClusterNode
-			derr := instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			derr := instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Inspect(clusterproperty.NodesV3, func(clonable data.Clonable) fail.Error {
 					nodesV3, ok := clonable.(*propertiesv3.ClusterNodes)
 					if !ok {
@@ -1854,19 +1854,17 @@ func (instance *Cluster) taskCreateMaster(task concurrency.Task, params concurre
 	}
 
 	// -- Create the Host --
-	xerr = subnet.Inspect(
-		func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
-			as, ok := clonable.(*abstract.Subnet)
-			if !ok {
-				return fail.InconsistentError(
-					"'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String(),
-				)
-			}
+	xerr = subnet.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+		as, ok := clonable.(*abstract.Subnet)
+		if !ok {
+			return fail.InconsistentError(
+				"'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String(),
+			)
+		}
 
-			hostReq.Subnets = []*abstract.Subnet{as}
-			return nil
-		},
-	)
+		hostReq.Subnets = []*abstract.Subnet{as}
+		return nil
+	})
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr
@@ -2423,7 +2421,7 @@ func (instance *Cluster) taskCreateNode(task concurrency.Task, params concurrenc
 	}
 
 	// -- Create the Host instance corresponding to the new node --
-	xerr = subnet.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = subnet.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/clusterunsafe.go
+++ b/lib/server/resources/operations/clusterunsafe.go
@@ -86,7 +86,7 @@ func (instance *Cluster) unsafeGetState() (state clusterstate.Enum, ferr fail.Er
 	state = clusterstate.Unknown
 	instance.localCache.RLock()
 	makers := instance.localCache.makers
-	instance.localCache.RUnlock() //nolint
+	instance.localCache.RUnlock() // nolint
 	if makers.GetState != nil {
 		var xerr fail.Error
 		state, xerr = makers.GetState(instance)
@@ -95,7 +95,7 @@ func (instance *Cluster) unsafeGetState() (state clusterstate.Enum, ferr fail.Er
 			return clusterstate.Unknown, xerr
 		}
 
-		return state, instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+		return state, instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 			return props.Alter(clusterproperty.StateV1, func(clonable data.Clonable) fail.Error {
 				stateV1, ok := clonable.(*propertiesv1.ClusterState)
 				if !ok {
@@ -105,7 +105,7 @@ func (instance *Cluster) unsafeGetState() (state clusterstate.Enum, ferr fail.Er
 				stateV1.State = state
 				instance.localCache.Lock()
 				instance.localCache.lastStateCollection = time.Now()
-				instance.localCache.Unlock() //nolint
+				instance.localCache.Unlock() // nolint
 				return nil
 			})
 		})

--- a/lib/server/resources/operations/converters/resources.go
+++ b/lib/server/resources/operations/converters/resources.go
@@ -17,6 +17,8 @@
 package converters
 
 import (
+	"context"
+
 	"github.com/CS-SI/SafeScale/v22/lib/protocol"
 	"github.com/CS-SI/SafeScale/v22/lib/server/resources"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/fail"
@@ -38,11 +40,11 @@ func IndexedListOfClusterNodesFromResourceToProtocol(in resources.IndexedListOfC
 	return out, nil
 }
 
-func FeatureSliceFromResourceToProtocol(in []resources.Feature) *protocol.FeatureListResponse {
+func FeatureSliceFromResourceToProtocol(ctx context.Context, in []resources.Feature) *protocol.FeatureListResponse {
 	out := &protocol.FeatureListResponse{}
 	out.Features = make([]*protocol.FeatureResponse, 0, len(in))
 	for _, v := range in {
-		out.Features = append(out.Features, v.ToProtocol())
+		out.Features = append(out.Features, v.ToProtocol(ctx))
 	}
 	return out
 }

--- a/lib/server/resources/operations/converters/resources_test.go
+++ b/lib/server/resources/operations/converters/resources_test.go
@@ -17,6 +17,7 @@
 package converters
 
 import (
+	"context"
 	"testing"
 
 	"github.com/CS-SI/SafeScale/v22/lib/server/resources"
@@ -73,7 +74,7 @@ func Test_IndexedListOfClusterNodesFromResourceToProtocol(t *testing.T) {
 func Test_FeatureSliceFromResourceToProtocol(t *testing.T) {
 
 	rf := []resources.Feature{}
-	flr := FeatureSliceFromResourceToProtocol(rf)
+	flr := FeatureSliceFromResourceToProtocol(context.Background(), rf)
 	if len(flr.Features) != 0 {
 		t.Error("Invalid FeatureListResponse len")
 		t.Fail()

--- a/lib/server/resources/operations/feature.go
+++ b/lib/server/resources/operations/feature.go
@@ -213,7 +213,7 @@ func (instance *Feature) Applicable(ctx context.Context, tg resources.Targetable
 		if !ok {
 			return false, fail.InconsistentError("failed to cast target as '*Cluster'")
 		}
-		flavor, xerr := casted.GetFlavor()
+		flavor, xerr := casted.GetFlavor(nil)
 		if xerr != nil {
 			return false, fail.Wrap(xerr, "failed to get Cluster Flavor")
 		}
@@ -766,7 +766,7 @@ func unregisterOnSuccessfulHostsInCluster(ctx context.Context, svc iaas.Service,
 }
 
 // ToProtocol converts a Feature to *protocol.FeatureResponse
-func (instance Feature) ToProtocol() *protocol.FeatureResponse {
+func (instance Feature) ToProtocol(context.Context) *protocol.FeatureResponse {
 	out := &protocol.FeatureResponse{
 		Name:     instance.GetName(),
 		FileName: instance.GetDisplayFilename(nil),

--- a/lib/server/resources/operations/feature.go
+++ b/lib/server/resources/operations/feature.go
@@ -153,7 +153,7 @@ func (instance *Feature) GetID() string {
 }
 
 // GetFilename returns the filename of the Feature definition, with error handling
-func (instance *Feature) GetFilename() string {
+func (instance *Feature) GetFilename(context.Context) string {
 	if valid.IsNil(instance) {
 		return ""
 	}
@@ -162,7 +162,7 @@ func (instance *Feature) GetFilename() string {
 }
 
 // GetDisplayFilename returns the filename of the Feature definition, beautifulled, with error handling
-func (instance *Feature) GetDisplayFilename() string {
+func (instance *Feature) GetDisplayFilename(context.Context) string {
 	if valid.IsNil(instance) {
 		return ""
 	}
@@ -201,15 +201,15 @@ func (instance *Feature) Specs() *viper.Viper {
 }
 
 // Applicable tells if the Feature is installable on the target
-func (instance *Feature) Applicable(t resources.Targetable) (bool, fail.Error) {
+func (instance *Feature) Applicable(ctx context.Context, tg resources.Targetable) (bool, fail.Error) {
 	if valid.IsNil(instance) {
 		return false, fail.InvalidInstanceError()
 	}
 
 	// 1st check Feature is suitable for target
-	switch t.TargetType() {
+	switch tg.TargetType() {
 	case featuretargettype.Cluster:
-		casted, ok := t.(*Cluster)
+		casted, ok := tg.(*Cluster)
 		if !ok {
 			return false, fail.InconsistentError("failed to cast target as '*Cluster'")
 		}
@@ -228,14 +228,14 @@ func (instance *Feature) Applicable(t resources.Targetable) (bool, fail.Error) {
 	}
 
 	// 2nd in case of a cluster, check cluster sizing requirements
-	switch t.TargetType() {
+	switch tg.TargetType() {
 	case featuretargettype.Cluster:
 		// FIXME: implement this
 	default:
 	}
 
 	// 2nd check there is an install method the target can use
-	methods, xerr := t.InstallMethods()
+	methods, xerr := tg.InstallMethods(ctx)
 	if xerr != nil {
 		return false, xerr
 	}
@@ -337,7 +337,7 @@ func (instance *Feature) Check(ctx context.Context, target resources.Targetable,
 	}
 
 	// -- fall back to active check
-	installer, xerr := instance.determineInstallerForTarget(target, "check")
+	installer, xerr := instance.determineInstallerForTarget(ctx, target, "check")
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr
@@ -433,8 +433,8 @@ func (instance *Feature) conditionParameters(ctx context.Context, externals data
 }
 
 // determineInstallerForTarget isolates the available installer to use for target (one that is define in the file and applicable on target)
-func (instance *Feature) determineInstallerForTarget(target resources.Targetable, action string) (_ Installer, ferr fail.Error) {
-	methods, xerr := target.InstallMethods()
+func (instance *Feature) determineInstallerForTarget(ctx context.Context, target resources.Targetable, action string) (_ Installer, ferr fail.Error) {
+	methods, xerr := target.InstallMethods(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -489,7 +489,7 @@ func (instance *Feature) Add(ctx context.Context, target resources.Targetable, v
 		fmt.Sprintf("Ending addition of Feature '%s' on %s '%s'", featureName, targetType, targetName),
 	)()
 
-	installer, xerr := instance.determineInstallerForTarget(target, "check")
+	installer, xerr := instance.determineInstallerForTarget(ctx, target, "check")
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr
@@ -537,7 +537,7 @@ func (instance *Feature) Add(ctx context.Context, target resources.Targetable, v
 	// FIXME: restore Feature check cache using iaas.ResourceCache
 	// _ = checkCache.ForceSet(featureName()+"@"+targetName, results)
 
-	return results, target.RegisterFeature(instance, nil, target.TargetType() == featuretargettype.Cluster)
+	return results, target.RegisterFeature(ctx, instance, nil, target.TargetType() == featuretargettype.Cluster)
 }
 
 // Remove uninstalls the Feature from the target
@@ -572,7 +572,7 @@ func (instance *Feature) Remove(ctx context.Context, target resources.Targetable
 		// installer Installer
 	)
 
-	installer, xerr := instance.determineInstallerForTarget(target, "check")
+	installer, xerr := instance.determineInstallerForTarget(ctx, target, "check")
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr
@@ -601,11 +601,11 @@ func (instance *Feature) Remove(ctx context.Context, target resources.Targetable
 		return nil, xerr
 	}
 
-	return results, target.UnregisterFeature(instance.GetName())
+	return results, target.UnregisterFeature(ctx, instance.GetName())
 }
 
 // Dependencies returns a list of features needed as dependencies
-func (instance *Feature) Dependencies() (map[string]struct{}, fail.Error) {
+func (instance *Feature) Dependencies(context.Context) (map[string]struct{}, fail.Error) {
 	emptyMap := map[string]struct{}{}
 	if valid.IsNil(instance) {
 		return emptyMap, fail.InvalidInstanceError()
@@ -690,7 +690,7 @@ func (instance *Feature) installRequirements(ctx context.Context, t resources.Ta
 				}
 
 				// Register the needed Feature as a requirement for instance
-				xerr = t.RegisterFeature(needed, instance, targetIsCluster)
+				xerr = t.RegisterFeature(ctx, needed, instance, targetIsCluster)
 				xerr = debug.InjectPlannedFail(xerr)
 				if xerr != nil {
 					return xerr
@@ -723,7 +723,7 @@ func registerOnSuccessfulHostsInCluster(ctx context.Context, svc iaas.Service, t
 				return xerr
 			}
 
-			xerr = host.RegisterFeature(installed, requiredBy, true)
+			xerr = host.RegisterFeature(ctx, installed, requiredBy, true)
 			xerr = debug.InjectPlannedFail(xerr)
 			if xerr != nil {
 				return xerr
@@ -755,7 +755,7 @@ func unregisterOnSuccessfulHostsInCluster(ctx context.Context, svc iaas.Service,
 				return xerr
 			}
 
-			xerr = host.UnregisterFeature(installed.GetName())
+			xerr = host.UnregisterFeature(ctx, installed.GetName())
 			xerr = debug.InjectPlannedFail(xerr)
 			if xerr != nil {
 				return xerr
@@ -769,13 +769,13 @@ func unregisterOnSuccessfulHostsInCluster(ctx context.Context, svc iaas.Service,
 func (instance Feature) ToProtocol() *protocol.FeatureResponse {
 	out := &protocol.FeatureResponse{
 		Name:     instance.GetName(),
-		FileName: instance.GetDisplayFilename(),
+		FileName: instance.GetDisplayFilename(nil),
 	}
 	return out
 }
 
 // ListParametersWithControl returns a slice of parameter names that have control script
-func (instance Feature) ListParametersWithControl() []string {
+func (instance Feature) ListParametersWithControl(context.Context) []string {
 	out := make([]string, 0, len(instance.file.versionControl))
 	for k := range instance.file.versionControl {
 		out = append(out, k)
@@ -895,7 +895,7 @@ func filterEligibleFeatures(ctx context.Context, target resources.Targetable, fi
 			}
 		}
 
-		ok, xerr := entry.Applicable(target)
+		ok, xerr := entry.Applicable(ctx, target)
 		if xerr != nil {
 			return nil, xerr
 		}

--- a/lib/server/resources/operations/feature.go
+++ b/lib/server/resources/operations/feature.go
@@ -313,7 +313,7 @@ func (instance *Feature) Check(ctx context.Context, target resources.Targetable,
 
 	switch ata := target.(type) {
 	case resources.Host:
-		state, xerr := ata.GetState()
+		state, xerr := ata.GetState(ctx)
 		if xerr != nil {
 			return nil, xerr
 		}

--- a/lib/server/resources/operations/feature.go
+++ b/lib/server/resources/operations/feature.go
@@ -213,7 +213,7 @@ func (instance *Feature) Applicable(ctx context.Context, tg resources.Targetable
 		if !ok {
 			return false, fail.InconsistentError("failed to cast target as '*Cluster'")
 		}
-		flavor, xerr := casted.GetFlavor(nil)
+		flavor, xerr := casted.GetFlavor(ctx)
 		if xerr != nil {
 			return false, fail.Wrap(xerr, "failed to get Cluster Flavor")
 		}
@@ -769,7 +769,7 @@ func unregisterOnSuccessfulHostsInCluster(ctx context.Context, svc iaas.Service,
 func (instance Feature) ToProtocol(ctx context.Context) *protocol.FeatureResponse {
 	out := &protocol.FeatureResponse{
 		Name:     instance.GetName(),
-		FileName: instance.GetDisplayFilename(nil),
+		FileName: instance.GetDisplayFilename(ctx),
 	}
 	return out
 }

--- a/lib/server/resources/operations/feature.go
+++ b/lib/server/resources/operations/feature.go
@@ -153,7 +153,7 @@ func (instance *Feature) GetID() string {
 }
 
 // GetFilename returns the filename of the Feature definition, with error handling
-func (instance *Feature) GetFilename(context.Context) string {
+func (instance *Feature) GetFilename(ctx context.Context) string {
 	if valid.IsNil(instance) {
 		return ""
 	}
@@ -162,7 +162,7 @@ func (instance *Feature) GetFilename(context.Context) string {
 }
 
 // GetDisplayFilename returns the filename of the Feature definition, beautifulled, with error handling
-func (instance *Feature) GetDisplayFilename(context.Context) string {
+func (instance *Feature) GetDisplayFilename(ctx context.Context) string {
 	if valid.IsNil(instance) {
 		return ""
 	}
@@ -286,7 +286,7 @@ func (instance *Feature) Check(ctx context.Context, target resources.Targetable,
 			return &results{}, fail.InconsistentError("failed to cast target to '*Host'")
 		}
 
-		xerr = castedTarget.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+		xerr = castedTarget.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 			return props.Inspect(hostproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 				hostFeaturesV1, ok := clonable.(*propertiesv1.HostFeatures)
 				if !ok {
@@ -605,7 +605,7 @@ func (instance *Feature) Remove(ctx context.Context, target resources.Targetable
 }
 
 // Dependencies returns a list of features needed as dependencies
-func (instance *Feature) Dependencies(context.Context) (map[string]struct{}, fail.Error) {
+func (instance *Feature) Dependencies(ctx context.Context) (map[string]struct{}, fail.Error) {
 	emptyMap := map[string]struct{}{}
 	if valid.IsNil(instance) {
 		return emptyMap, fail.InvalidInstanceError()
@@ -766,7 +766,7 @@ func unregisterOnSuccessfulHostsInCluster(ctx context.Context, svc iaas.Service,
 }
 
 // ToProtocol converts a Feature to *protocol.FeatureResponse
-func (instance Feature) ToProtocol(context.Context) *protocol.FeatureResponse {
+func (instance Feature) ToProtocol(ctx context.Context) *protocol.FeatureResponse {
 	out := &protocol.FeatureResponse{
 		Name:     instance.GetName(),
 		FileName: instance.GetDisplayFilename(nil),
@@ -775,7 +775,7 @@ func (instance Feature) ToProtocol(context.Context) *protocol.FeatureResponse {
 }
 
 // ListParametersWithControl returns a slice of parameter names that have control script
-func (instance Feature) ListParametersWithControl(context.Context) []string {
+func (instance Feature) ListParametersWithControl(ctx context.Context) []string {
 	out := make([]string, 0, len(instance.file.versionControl))
 	for k := range instance.file.versionControl {
 		out = append(out, k)

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -2950,7 +2950,7 @@ func (instance *Host) GetShare(ctx context.Context, shareRef string) (_ *propert
 }
 
 // GetVolumes returns information about volumes attached to the Host
-func (instance *Host) GetVolumes() (_ *propertiesv1.HostVolumes, ferr fail.Error) {
+func (instance *Host) GetVolumes(context.Context) (_ *propertiesv1.HostVolumes, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -3355,7 +3355,7 @@ func (instance *Host) GetShares(context.Context) (shares *propertiesv1.HostShare
 }
 
 // GetMounts returns the information abouts the mounts of the Host
-func (instance *Host) GetMounts() (mounts *propertiesv1.HostMounts, ferr fail.Error) {
+func (instance *Host) GetMounts(context.Context) (mounts *propertiesv1.HostMounts, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	mounts = nil
@@ -3370,7 +3370,7 @@ func (instance *Host) GetMounts() (mounts *propertiesv1.HostMounts, ferr fail.Er
 }
 
 // IsClusterMember returns true if the Host is member of a cluster
-func (instance *Host) IsClusterMember() (yes bool, ferr fail.Error) {
+func (instance *Host) IsClusterMember(context.Context) (yes bool, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	yes = false
@@ -3430,7 +3430,7 @@ func (instance *Host) IsGateway() (_ bool, ferr fail.Error) {
 }
 
 // IsSingle tells if the Host is single
-func (instance *Host) IsSingle() (_ bool, ferr fail.Error) {
+func (instance *Host) IsSingle(context.Context) (_ bool, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -3276,10 +3276,10 @@ func (instance *Host) GetPrivateIP(ctx context.Context) (_ string, ferr fail.Err
 }
 
 // GetPrivateIPOnSubnet returns the private IP of the Host on its default Subnet
-func (instance *Host) GetPrivateIPOnSubnet(subnetID string) (ip string, ferr fail.Error) {
+func (instance *Host) GetPrivateIPOnSubnet(ctx context.Context, subnetID string) (_ string, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
-	ip = ""
+	ip := ""
 	if valid.IsNil(instance) {
 		return ip, fail.InvalidInstanceError()
 	}
@@ -3329,7 +3329,7 @@ func (instance *Host) GetAccessIP(ctx context.Context) (_ string, ferr fail.Erro
 }
 
 // GetShares returns the information about the shares hosted by the Host
-func (instance *Host) GetShares() (shares *propertiesv1.HostShares, ferr fail.Error) {
+func (instance *Host) GetShares(context.Context) (shares *propertiesv1.HostShares, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	shares = &propertiesv1.HostShares{}
@@ -3770,7 +3770,7 @@ func (instance *Host) UnbindSecurityGroup(ctx context.Context, sgInstance resour
 }
 
 // ListSecurityGroups returns a slice of security groups bound to Host
-func (instance *Host) ListSecurityGroups(state securitygroupstate.Enum) (list []*propertiesv1.SecurityGroupBond, ferr fail.Error) {
+func (instance *Host) ListSecurityGroups(ctx context.Context, state securitygroupstate.Enum) (list []*propertiesv1.SecurityGroupBond, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	var emptySlice []*propertiesv1.SecurityGroupBond

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -138,7 +138,7 @@ func onHostCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Id
 		return nil, innerXErr
 	}
 
-	serialized, xerr := hostInstance.Sdump()
+	serialized, xerr := hostInstance.Sdump(nil)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -152,7 +152,7 @@ func onHostCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Id
 		return nil, xerr
 	}
 
-	afterSerialized, xerr := hostInstance.Sdump()
+	afterSerialized, xerr := hostInstance.Sdump(nil)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -507,7 +507,7 @@ func (instance *Host) ForceGetState(ctx context.Context) (state hoststate.Enum, 
 }
 
 // Reload reloads Host from metadata and current Host state on provider state
-func (instance *Host) Reload() (ferr fail.Error) {
+func (instance *Host) Reload(context.Context) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -522,7 +522,7 @@ func (instance *Host) Reload() (ferr fail.Error) {
 func (instance *Host) unsafeReload() (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
-	xerr := instance.MetadataCore.Reload()
+	xerr := instance.MetadataCore.Reload(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		switch xerr.(type) {

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -2409,7 +2409,7 @@ func (instance *Host) RelaxedDeleteHost(ctx context.Context) (ferr fail.Error) {
 				}
 
 				// Retrieve data about v from its server
-				item, loopErr := hostServer.GetShare(i.ShareID)
+				item, loopErr := hostServer.GetShare(ctx, i.ShareID)
 				if loopErr != nil {
 					return loopErr
 				}
@@ -2887,7 +2887,7 @@ func (instance *Host) Push(
 }
 
 // GetShare returns a clone of the propertiesv1.HostShare corresponding to share 'shareRef'
-func (instance *Host) GetShare(shareRef string) (_ *propertiesv1.HostShare, ferr fail.Error) {
+func (instance *Host) GetShare(ctx context.Context, shareRef string) (_ *propertiesv1.HostShare, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -435,21 +435,19 @@ func (instance *Host) Browse(ctx context.Context, callback func(*abstract.HostCo
 	// instance.RLock()
 	// defer instance.RUnlock()
 
-	return instance.MetadataCore.BrowseFolder(
-		func(buf []byte) (innerXErr fail.Error) {
-			if task.Aborted() {
-				return fail.AbortedError(nil, "aborted")
-			}
+	return instance.MetadataCore.BrowseFolder(ctx, func(buf []byte) (innerXErr fail.Error) {
+		if task.Aborted() {
+			return fail.AbortedError(nil, "aborted")
+		}
 
-			ahc := abstract.NewHostCore()
-			var inErr fail.Error
-			if inErr = ahc.Deserialize(buf); inErr != nil {
-				return inErr
-			}
+		ahc := abstract.NewHostCore()
+		var inErr fail.Error
+		if inErr = ahc.Deserialize(buf); inErr != nil {
+			return inErr
+		}
 
-			return callback(ahc)
-		},
-	)
+		return callback(ahc)
+	})
 }
 
 // ForceGetState returns the current state of the provider Host then alter metadata

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -614,7 +614,7 @@ func (instance *Host) unsafeReload() (ferr fail.Error) {
 }
 
 // GetState returns the last known state of the Host, without forced inspect
-func (instance *Host) GetState() (hoststate.Enum, fail.Error) {
+func (instance *Host) GetState(context.Context) (hoststate.Enum, fail.Error) {
 	state := hoststate.Unknown
 	if instance == nil || valid.IsNil(instance) {
 		return state, fail.InvalidInstanceError()
@@ -2735,7 +2735,7 @@ func (instance *Host) Run(ctx context.Context, cmd string, outs outputs.Enum, co
 	targetName := instance.GetName()
 
 	var state hoststate.Enum
-	state, xerr = instance.GetState()
+	state, xerr = instance.GetState(nil)
 	if xerr != nil {
 		return invalid, "", "", xerr
 	}
@@ -2789,7 +2789,7 @@ func (instance *Host) Pull(ctx context.Context, target, source string, timeout t
 	targetName := instance.GetName()
 
 	var state hoststate.Enum
-	state, xerr = instance.GetState()
+	state, xerr = instance.GetState(nil)
 	if xerr != nil {
 		return invalid, "", "", xerr
 	}
@@ -2874,7 +2874,7 @@ func (instance *Host) Push(
 	targetName := instance.GetName()
 
 	var state hoststate.Enum
-	state, xerr = instance.GetState()
+	state, xerr = instance.GetState(nil)
 	if xerr != nil {
 		return invalid, "", "", xerr
 	}
@@ -3399,7 +3399,7 @@ func (instance *Host) IsClusterMember(context.Context) (yes bool, ferr fail.Erro
 }
 
 // IsGateway tells if the Host acts as a gateway for a Subnet
-func (instance *Host) IsGateway() (_ bool, ferr fail.Error) {
+func (instance *Host) IsGateway(context.Context) (_ bool, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -3502,7 +3502,7 @@ func (instance *Host) PushStringToFileWithOwnership(
 	targetName := instance.GetName()
 
 	var state hoststate.Enum
-	state, xerr = instance.GetState()
+	state, xerr = instance.GetState(nil)
 	if xerr != nil {
 		return xerr
 	}

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -143,7 +143,7 @@ func onHostCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Id
 		return nil, xerr
 	}
 
-	if innerXErr = hostInstance.Read(ref); innerXErr != nil {
+	if innerXErr = hostInstance.Read(ctx, ref); innerXErr != nil {
 		return nil, innerXErr
 	}
 

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -164,6 +164,10 @@ func onHostCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Id
 	return hostInstance, nil
 }
 
+func (instance *Host) Exists() (bool, fail.Error) {
+	return true, nil
+}
+
 // updateCachedInformation loads in cache SSH configuration to access host; this information will not change over time
 func (instance *Host) updateCachedInformation() fail.Error {
 	svc := instance.Service()

--- a/lib/server/resources/operations/hostinstall.go
+++ b/lib/server/resources/operations/hostinstall.go
@@ -71,7 +71,7 @@ func (instance *Host) AddFeature(ctx context.Context, name string, vars data.Map
 	targetName := instance.GetName()
 
 	var state hoststate.Enum
-	state, xerr = instance.GetState(nil)
+	state, xerr = instance.GetState(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -86,7 +86,7 @@ func (instance *Host) AddFeature(ctx context.Context, name string, vars data.Map
 		return nil, xerr
 	}
 
-	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var innerXErr fail.Error
 		outcomes, innerXErr = feat.Add(task.Context(), instance, vars, settings)
 		if innerXErr != nil {
@@ -188,7 +188,7 @@ func (instance *Host) DeleteFeature(ctx context.Context, name string, vars data.
 	targetName := instance.GetName()
 
 	var state hoststate.Enum
-	state, xerr = instance.GetState(nil)
+	state, xerr = instance.GetState(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -203,7 +203,7 @@ func (instance *Host) DeleteFeature(ctx context.Context, name string, vars data.
 		return nil, xerr
 	}
 
-	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		outcomes, innerXErr := feat.Remove(task.Context(), instance, vars, settings)
 		if innerXErr != nil {
 			return fail.NewError(innerXErr, nil, "error uninstalling feature '%s' on '%s'", name, instance.GetName())
@@ -241,7 +241,7 @@ func (instance *Host) TargetType() featuretargettype.Enum {
 
 // InstallMethods returns a list of installation methods usable on the target, ordered from upper to lower preference (1 = highest preference)
 // satisfies interface install.Targetable
-func (instance *Host) InstallMethods(context.Context) (map[uint8]installmethod.Enum, fail.Error) {
+func (instance *Host) InstallMethods(ctx context.Context) (map[uint8]installmethod.Enum, fail.Error) {
 	if instance == nil || valid.IsNil(instance) {
 		return map[uint8]installmethod.Enum{}, fail.InvalidInstanceError()
 	}
@@ -268,7 +268,7 @@ func (instance *Host) RegisterFeature(ctx context.Context, feat resources.Featur
 		return fail.InvalidParameterCannotBeNilError("feat")
 	}
 
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.HostFeatures)
 			if !ok {
@@ -317,7 +317,7 @@ func (instance *Host) UnregisterFeature(ctx context.Context, feat string) (ferr 
 		return fail.InvalidParameterError("feat", "cannot be empty string")
 	}
 
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.HostFeatures)
 			if !ok {
@@ -377,13 +377,13 @@ func (instance *Host) ListInstalledFeatures(ctx context.Context) (_ []resources.
 
 // InstalledFeatures returns a slice of installed features
 // satisfies interface resources.Targetable
-func (instance *Host) InstalledFeatures(context.Context) []string {
+func (instance *Host) InstalledFeatures(ctx context.Context) []string {
 	if instance == nil {
 		return []string{}
 	}
 
 	var out []string
-	xerr := instance.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.HostFeatures)
 			if !ok {
@@ -418,7 +418,7 @@ func (instance *Host) ComplementFeatureParameters(ctx context.Context, v data.Ma
 	v["ShortHostname"] = instance.GetName()
 	domain := ""
 
-	xerr := instance.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.DescriptionV1, func(clonable data.Clonable) fail.Error {
 			hostDescriptionV1, ok := clonable.(*propertiesv1.HostDescription)
 			if !ok {

--- a/lib/server/resources/operations/hostinstall.go
+++ b/lib/server/resources/operations/hostinstall.go
@@ -100,7 +100,7 @@ func (instance *Host) AddFeature(ctx context.Context, name string, vars data.Map
 				return fail.InconsistentError("expected '*propertiesv1.HostFeatures', received '%s'", reflect.TypeOf(clonable))
 			}
 
-			requires, innerXErr := feat.Dependencies()
+			requires, innerXErr := feat.Dependencies(ctx)
 			if innerXErr != nil {
 				return innerXErr
 			}
@@ -241,7 +241,7 @@ func (instance *Host) TargetType() featuretargettype.Enum {
 
 // InstallMethods returns a list of installation methods usable on the target, ordered from upper to lower preference (1 = highest preference)
 // satisfies interface install.Targetable
-func (instance *Host) InstallMethods() (map[uint8]installmethod.Enum, fail.Error) {
+func (instance *Host) InstallMethods(context.Context) (map[uint8]installmethod.Enum, fail.Error) {
 	if instance == nil || valid.IsNil(instance) {
 		return map[uint8]installmethod.Enum{}, fail.InvalidInstanceError()
 	}
@@ -258,7 +258,7 @@ func (instance *Host) InstallMethods() (map[uint8]installmethod.Enum, fail.Error
 }
 
 // RegisterFeature registers an installed Feature in metadata of Host
-func (instance *Host) RegisterFeature(feat resources.Feature, requiredBy resources.Feature, clusterContext bool) (ferr fail.Error) {
+func (instance *Host) RegisterFeature(ctx context.Context, feat resources.Feature, requiredBy resources.Feature, clusterContext bool) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -277,7 +277,7 @@ func (instance *Host) RegisterFeature(feat resources.Feature, requiredBy resourc
 
 			var item *propertiesv1.HostInstalledFeature
 			if item, ok = featuresV1.Installed[feat.GetName()]; !ok {
-				requirements, innerXErr := feat.Dependencies()
+				requirements, innerXErr := feat.Dependencies(ctx)
 				if innerXErr != nil {
 					return innerXErr
 				}
@@ -307,7 +307,7 @@ func (instance *Host) RegisterFeature(feat resources.Feature, requiredBy resourc
 }
 
 // UnregisterFeature unregisters a Feature from Cluster metadata
-func (instance *Host) UnregisterFeature(feat string) (ferr fail.Error) {
+func (instance *Host) UnregisterFeature(ctx context.Context, feat string) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -361,7 +361,7 @@ func (instance *Host) ListInstalledFeatures(ctx context.Context) (_ []resources.
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	list := instance.InstalledFeatures()
+	list := instance.InstalledFeatures(nil)
 	out := make([]resources.Feature, 0, len(list))
 	for _, v := range list {
 		item, xerr := NewFeature(ctx, instance.Service(), v)
@@ -377,7 +377,7 @@ func (instance *Host) ListInstalledFeatures(ctx context.Context) (_ []resources.
 
 // InstalledFeatures returns a slice of installed features
 // satisfies interface resources.Targetable
-func (instance *Host) InstalledFeatures() []string {
+func (instance *Host) InstalledFeatures(context.Context) []string {
 	if instance == nil {
 		return []string{}
 	}

--- a/lib/server/resources/operations/hostinstall.go
+++ b/lib/server/resources/operations/hostinstall.go
@@ -86,7 +86,7 @@ func (instance *Host) AddFeature(ctx context.Context, name string, vars data.Map
 		return nil, xerr
 	}
 
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var innerXErr fail.Error
 		outcomes, innerXErr = feat.Add(task.Context(), instance, vars, settings)
 		if innerXErr != nil {
@@ -203,7 +203,7 @@ func (instance *Host) DeleteFeature(ctx context.Context, name string, vars data.
 		return nil, xerr
 	}
 
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		outcomes, innerXErr := feat.Remove(task.Context(), instance, vars, settings)
 		if innerXErr != nil {
 			return fail.NewError(innerXErr, nil, "error uninstalling feature '%s' on '%s'", name, instance.GetName())
@@ -268,7 +268,7 @@ func (instance *Host) RegisterFeature(ctx context.Context, feat resources.Featur
 		return fail.InvalidParameterCannotBeNilError("feat")
 	}
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.HostFeatures)
 			if !ok {
@@ -317,7 +317,7 @@ func (instance *Host) UnregisterFeature(ctx context.Context, feat string) (ferr 
 		return fail.InvalidParameterError("feat", "cannot be empty string")
 	}
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.HostFeatures)
 			if !ok {

--- a/lib/server/resources/operations/hostinstall.go
+++ b/lib/server/resources/operations/hostinstall.go
@@ -470,7 +470,7 @@ func (instance *Host) ComplementFeatureParameters(ctx context.Context, v data.Ma
 		return xerr
 	}
 
-	single, xerr := instance.IsSingle()
+	single, xerr := instance.IsSingle(nil)
 	if xerr != nil {
 		return xerr
 	}
@@ -537,7 +537,7 @@ func (instance *Host) ComplementFeatureParameters(ctx context.Context, v data.Ma
 }
 
 // IsFeatureInstalled ...
-func (instance *Host) IsFeatureInstalled(name string) (found bool, ferr fail.Error) {
+func (instance *Host) IsFeatureInstalled(ctx context.Context, name string) (found bool, ferr fail.Error) {
 	found = false
 	defer fail.OnPanic(&ferr)
 

--- a/lib/server/resources/operations/hostinstall.go
+++ b/lib/server/resources/operations/hostinstall.go
@@ -361,7 +361,7 @@ func (instance *Host) ListInstalledFeatures(ctx context.Context) (_ []resources.
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	list := instance.InstalledFeatures(nil)
+	list := instance.InstalledFeatures(ctx)
 	out := make([]resources.Feature, 0, len(list))
 	for _, v := range list {
 		item, xerr := NewFeature(ctx, instance.Service(), v)
@@ -470,7 +470,7 @@ func (instance *Host) ComplementFeatureParameters(ctx context.Context, v data.Ma
 		return xerr
 	}
 
-	single, xerr := instance.IsSingle(nil)
+	single, xerr := instance.IsSingle(ctx)
 	if xerr != nil {
 		return xerr
 	}

--- a/lib/server/resources/operations/hostinstall.go
+++ b/lib/server/resources/operations/hostinstall.go
@@ -71,7 +71,7 @@ func (instance *Host) AddFeature(ctx context.Context, name string, vars data.Map
 	targetName := instance.GetName()
 
 	var state hoststate.Enum
-	state, xerr = instance.GetState()
+	state, xerr = instance.GetState(nil)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -188,7 +188,7 @@ func (instance *Host) DeleteFeature(ctx context.Context, name string, vars data.
 	targetName := instance.GetName()
 
 	var state hoststate.Enum
-	state, xerr = instance.GetState()
+	state, xerr = instance.GetState(nil)
 	if xerr != nil {
 		return nil, xerr
 	}

--- a/lib/server/resources/operations/hostinstall.go
+++ b/lib/server/resources/operations/hostinstall.go
@@ -548,7 +548,7 @@ func (instance *Host) IsFeatureInstalled(ctx context.Context, name string) (foun
 		return false, fail.InvalidParameterError("name", "cannot be empty string")
 	}
 
-	return found, instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return found, instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 			featuresV1, ok := clonable.(*propertiesv1.HostFeatures)
 			if !ok {

--- a/lib/server/resources/operations/hostunsafe.go
+++ b/lib/server/resources/operations/hostunsafe.go
@@ -484,7 +484,7 @@ func (instance *Host) unsafeGetDefaultSubnet(ctx context.Context) (subnetInstanc
 	defer fail.OnPanic(&ferr)
 
 	svc := instance.Service()
-	xerr := instance.Review(func(_ data.Clonable, props *serialize.JSONProperties) (innerXErr fail.Error) {
+	xerr := instance.Review(ctx, func(_ data.Clonable, props *serialize.JSONProperties) (innerXErr fail.Error) {
 		if props.Lookup(hostproperty.NetworkV2) {
 			return props.Inspect(hostproperty.NetworkV2, func(clonable data.Clonable) fail.Error {
 				networkV2, ok := clonable.(*propertiesv2.HostNetworking)

--- a/lib/server/resources/operations/hostunsafe.go
+++ b/lib/server/resources/operations/hostunsafe.go
@@ -352,9 +352,9 @@ func (instance *Host) unsafePush(ctx context.Context, source, target, owner, mod
 
 // unsafeGetVolumes is the not goroutine-safe version of GetVolumes, without parameter validation, that does the real work
 // Note: must be used with wisdom
-func (instance *Host) unsafeGetVolumes() (*propertiesv1.HostVolumes, fail.Error) {
+func (instance *Host) unsafeGetVolumes(ctx context.Context) (*propertiesv1.HostVolumes, fail.Error) {
 	var hvV1 *propertiesv1.HostVolumes
-	xerr := instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr := instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.VolumesV1, func(clonable data.Clonable) fail.Error {
 			var ok bool
 			hvV1, ok = clonable.(*propertiesv1.HostVolumes)
@@ -375,8 +375,8 @@ func (instance *Host) unsafeGetVolumes() (*propertiesv1.HostVolumes, fail.Error)
 
 // unsafeGetMounts returns the information about the mounts of the host
 // Intended to be used when instance is notoriously not nil (because previously checked)
-func (instance *Host) unsafeGetMounts() (mounts *propertiesv1.HostMounts, ferr fail.Error) {
-	xerr := instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+func (instance *Host) unsafeGetMounts(ctx context.Context) (mounts *propertiesv1.HostMounts, ferr fail.Error) {
+	xerr := instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			hostMountsV1, ok := clonable.(*propertiesv1.HostMounts)
 			if !ok {

--- a/lib/server/resources/operations/installbybash.go
+++ b/lib/server/resources/operations/installbybash.go
@@ -50,10 +50,10 @@ func (i *bashInstaller) Check(ctx context.Context, f resources.Feature, t resour
 	yamlKey := "feature.install.bash.check"
 	if !f.(*Feature).Specs().IsSet(yamlKey) {
 		msg := `syntax error in Feature '%s' specification file (%s): no key '%s' found`
-		return nil, fail.SyntaxError(msg, f.GetName(), f.GetDisplayFilename(), yamlKey)
+		return nil, fail.SyntaxError(msg, f.GetName(), f.GetDisplayFilename(ctx), yamlKey)
 	}
 
-	w, xerr := newWorker(f, t, installmethod.Bash, installaction.Check, nil)
+	w, xerr := newWorker(ctx, f, t, installmethod.Bash, installaction.Check, nil)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -95,10 +95,10 @@ func (i *bashInstaller) Add(ctx context.Context, f resources.Feature, t resource
 	if !f.(*Feature).Specs().IsSet("feature.install.bash.add") {
 		msg := `syntax error in Feature '%s' specification file (%s):
 				no key 'feature.install.bash.add' found`
-		return nil, fail.SyntaxError(msg, f.GetName(), f.GetDisplayFilename())
+		return nil, fail.SyntaxError(msg, f.GetName(), f.GetDisplayFilename(ctx))
 	}
 
-	w, xerr := newWorker(f, t, installmethod.Bash, installaction.Add, nil)
+	w, xerr := newWorker(ctx, f, t, installmethod.Bash, installaction.Add, nil)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -144,10 +144,10 @@ func (i *bashInstaller) Remove(ctx context.Context, f resources.Feature, t resou
 	if !f.(*Feature).Specs().IsSet("feature.install.bash.remove") {
 		msg := `syntax error in Feature '%s' specification file (%s):
 				no key 'feature.install.bash.remove' found`
-		return nil, fail.SyntaxError(msg, f.GetName(), f.GetDisplayFilename())
+		return nil, fail.SyntaxError(msg, f.GetName(), f.GetDisplayFilename(ctx))
 	}
 
-	w, xerr := newWorker(f, t, installmethod.Bash, installaction.Remove, nil)
+	w, xerr := newWorker(ctx, f, t, installmethod.Bash, installaction.Remove, nil)
 	if xerr != nil {
 		return nil, xerr
 	}

--- a/lib/server/resources/operations/installbynone.go
+++ b/lib/server/resources/operations/installbynone.go
@@ -72,7 +72,7 @@ func (i *noneInstaller) Add(ctx context.Context, f resources.Feature, t resource
 		return nil, fail.InvalidParameterCannotBeNilError("t")
 	}
 
-	w, xerr := newWorker(f, t, installmethod.None, installaction.Add, nil)
+	w, xerr := newWorker(ctx, f, t, installmethod.None, installaction.Add, nil)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -106,7 +106,7 @@ func (i *noneInstaller) Remove(ctx context.Context, f resources.Feature, t resou
 		return nil, fail.InvalidParameterError("t", "cannot be nil")
 	}
 
-	w, xerr := newWorker(f, t, installmethod.None, installaction.Add, nil)
+	w, xerr := newWorker(ctx, f, t, installmethod.None, installaction.Add, nil)
 	if xerr != nil {
 		return nil, xerr
 	}

--- a/lib/server/resources/operations/installbyospkg.go
+++ b/lib/server/resources/operations/installbyospkg.go
@@ -57,10 +57,10 @@ func (g *genericPackager) Check(ctx context.Context, f resources.Feature, t reso
 
 	yamlKey := "feature.install." + g.keyword + ".check"
 	if !f.(*Feature).Specs().IsSet(yamlKey) {
-		return nil, fail.SyntaxError("syntax error in Feature '%s' specification file (%s): no key '%s' found", f.GetName(), f.GetDisplayFilename(), yamlKey)
+		return nil, fail.SyntaxError("syntax error in Feature '%s' specification file (%s): no key '%s' found", f.GetName(), f.GetDisplayFilename(ctx), yamlKey)
 	}
 
-	worker, xerr := newWorker(f, t, g.method, installaction.Check, g.checkCommand)
+	worker, xerr := newWorker(ctx, f, t, g.method, installaction.Check, g.checkCommand)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr
@@ -99,10 +99,10 @@ func (g *genericPackager) Add(ctx context.Context, f resources.Feature, t resour
 
 	yamlKey := "feature.install." + g.keyword + ".add"
 	if !f.(*Feature).Specs().IsSet(yamlKey) {
-		return nil, fail.SyntaxError("syntax error in Feature '%s' specification file (%s): no key '%s' found", f.GetName(), f.GetDisplayFilename(), yamlKey)
+		return nil, fail.SyntaxError("syntax error in Feature '%s' specification file (%s): no key '%s' found", f.GetName(), f.GetDisplayFilename(ctx), yamlKey)
 	}
 
-	worker, xerr := newWorker(f, t, g.method, installaction.Add, g.addCommand)
+	worker, xerr := newWorker(ctx, f, t, g.method, installaction.Add, g.addCommand)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		logrus.Println(xerr.Error())
@@ -142,10 +142,10 @@ func (g *genericPackager) Remove(ctx context.Context, f resources.Feature, t res
 
 	yamlKey := "feature.install." + g.keyword + ".remove"
 	if !f.(*Feature).Specs().IsSet(yamlKey) {
-		return nil, fail.SyntaxError("syntax error in Feature '%s' specification file (%s): no key '%s' found", f.GetName(), f.GetDisplayFilename(), yamlKey)
+		return nil, fail.SyntaxError("syntax error in Feature '%s' specification file (%s): no key '%s' found", f.GetName(), f.GetDisplayFilename(ctx), yamlKey)
 	}
 
-	worker, xerr := newWorker(f, t, g.method, installaction.Remove, g.removeCommand)
+	worker, xerr := newWorker(ctx, f, t, g.method, installaction.Remove, g.removeCommand)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr

--- a/lib/server/resources/operations/installstep.go
+++ b/lib/server/resources/operations/installstep.go
@@ -439,7 +439,7 @@ func (is *step) initLoopTurnForHost(ctx context.Context, host resources.Host, v 
 
 	clonedV["ShortHostname"] = host.GetName()
 	domain := ""
-	xerr = host.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = host.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.DescriptionV1, func(clonable data.Clonable) fail.Error {
 			hostDescriptionV1, ok := clonable.(*propertiesv1.HostDescription)
 			if !ok {

--- a/lib/server/resources/operations/installstep.go
+++ b/lib/server/resources/operations/installstep.go
@@ -464,7 +464,7 @@ func (is *step) initLoopTurnForHost(ctx context.Context, host resources.Host, v 
 	if xerr != nil {
 		return nil, xerr
 	}
-	clonedV["CIDR"], xerr = sn.GetCIDR()
+	clonedV["CIDR"], xerr = sn.GetCIDR(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}

--- a/lib/server/resources/operations/installworker.go
+++ b/lib/server/resources/operations/installworker.go
@@ -1146,7 +1146,7 @@ func (w *worker) setReverseProxy(ctx context.Context) (ferr fail.Error) {
 		return xerr
 	}
 
-	found, xerr := rgw.IsFeatureInstalled("edgeproxy4subnet")
+	found, xerr := rgw.IsFeatureInstalled(ctx, "edgeproxy4subnet")
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr

--- a/lib/server/resources/operations/installworker.go
+++ b/lib/server/resources/operations/installworker.go
@@ -1174,7 +1174,7 @@ func (w *worker) setReverseProxy(ctx context.Context) (ferr fail.Error) {
 	}
 
 	var secondaryKongController *KongController
-	if ok, _ := subnetInstance.HasVirtualIP(); ok {
+	if ok, _ := subnetInstance.HasVirtualIP(nil); ok {
 		secondaryKongController, xerr = NewKongController(ctx, w.service, subnetInstance, false)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr != nil {

--- a/lib/server/resources/operations/installworker.go
+++ b/lib/server/resources/operations/installworker.go
@@ -425,7 +425,7 @@ func (w *worker) identifyAvailableGateway(ctx context.Context) (resources.Host, 
 		w.availableGateway = gw
 	} else {
 		// In cluster context
-		netCfg, xerr := w.cluster.GetNetworkConfig()
+		netCfg, xerr := w.cluster.GetNetworkConfig(nil)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr != nil {
 			return nil, xerr
@@ -505,7 +505,7 @@ func (w *worker) identifyAllGateways(ctx context.Context) (_ []resources.Host, f
 
 	if w.cluster != nil {
 		var netCfg *propertiesv3.ClusterNetwork
-		netCfg, xerr = w.cluster.GetNetworkConfig()
+		netCfg, xerr = w.cluster.GetNetworkConfig(nil)
 		if xerr != nil {
 			return nil, xerr
 		}
@@ -1155,7 +1155,7 @@ func (w *worker) setReverseProxy(ctx context.Context) (ferr fail.Error) {
 		return nil
 	}
 
-	netprops, xerr := w.cluster.GetNetworkConfig()
+	netprops, xerr := w.cluster.GetNetworkConfig(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr
@@ -1562,7 +1562,7 @@ func (w *worker) setNetworkingSecurity(ctx context.Context) (ferr fail.Error) {
 	var rs resources.Subnet
 	if w.cluster != nil {
 		var netprops *propertiesv3.ClusterNetwork
-		if netprops, xerr = w.cluster.GetNetworkConfig(); xerr != nil {
+		if netprops, xerr = w.cluster.GetNetworkConfig(nil); xerr != nil {
 			xerr = debug.InjectPlannedFail(xerr)
 			if xerr != nil {
 				return xerr

--- a/lib/server/resources/operations/installworker.go
+++ b/lib/server/resources/operations/installworker.go
@@ -425,7 +425,7 @@ func (w *worker) identifyAvailableGateway(ctx context.Context) (resources.Host, 
 		w.availableGateway = gw
 	} else {
 		// In cluster context
-		netCfg, xerr := w.cluster.GetNetworkConfig(nil)
+		netCfg, xerr := w.cluster.GetNetworkConfig(ctx)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr != nil {
 			return nil, xerr
@@ -505,7 +505,7 @@ func (w *worker) identifyAllGateways(ctx context.Context) (_ []resources.Host, f
 
 	if w.cluster != nil {
 		var netCfg *propertiesv3.ClusterNetwork
-		netCfg, xerr = w.cluster.GetNetworkConfig(nil)
+		netCfg, xerr = w.cluster.GetNetworkConfig(ctx)
 		if xerr != nil {
 			return nil, xerr
 		}
@@ -644,7 +644,7 @@ func (w *worker) Proceed(ctx context.Context, params data.Map, settings resource
 		stepMap, ok := steps[strings.ToLower(k)].(map[string]interface{})
 		if !ok {
 			msg := `syntax error in Feature '%s' specification file (%s): no key '%s' found`
-			return outcomes, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(nil), stepKey)
+			return outcomes, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(ctx), stepKey)
 		}
 
 		// Determine list of hosts concerned by the step
@@ -669,7 +669,7 @@ func (w *worker) Proceed(ctx context.Context, params data.Map, settings resource
 				}
 			} else {
 				msg := `syntax error in Feature '%s' specification file (%s): no key '%s.%s' found`
-				return nil, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(nil), stepKey, yamlTargetsKeyword)
+				return nil, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(ctx), stepKey, yamlTargetsKeyword)
 			}
 
 			hostsList, xerr = w.identifyHosts(task.Context(), stepT)
@@ -889,7 +889,7 @@ func (w *worker) taskLaunchStep(task concurrency.Task, params concurrency.TaskPa
 		}
 	} else {
 		msg := `syntax error in Feature '%s' specification file (%s): no key '%s.%s' found`
-		return nil, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(nil), p.stepKey, yamlRunKeyword)
+		return nil, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(task.Context()), p.stepKey, yamlRunKeyword)
 	}
 
 	wallTime := timings.HostLongOperationTimeout()
@@ -1155,7 +1155,7 @@ func (w *worker) setReverseProxy(ctx context.Context) (ferr fail.Error) {
 		return nil
 	}
 
-	netprops, xerr := w.cluster.GetNetworkConfig(nil)
+	netprops, xerr := w.cluster.GetNetworkConfig(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr
@@ -1174,7 +1174,7 @@ func (w *worker) setReverseProxy(ctx context.Context) (ferr fail.Error) {
 	}
 
 	var secondaryKongController *KongController
-	if ok, _ := subnetInstance.HasVirtualIP(nil); ok {
+	if ok, _ := subnetInstance.HasVirtualIP(ctx); ok {
 		secondaryKongController, xerr = NewKongController(ctx, w.service, subnetInstance, false)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr != nil {
@@ -1562,7 +1562,7 @@ func (w *worker) setNetworkingSecurity(ctx context.Context) (ferr fail.Error) {
 	var rs resources.Subnet
 	if w.cluster != nil {
 		var netprops *propertiesv3.ClusterNetwork
-		if netprops, xerr = w.cluster.GetNetworkConfig(nil); xerr != nil {
+		if netprops, xerr = w.cluster.GetNetworkConfig(ctx); xerr != nil {
 			xerr = debug.InjectPlannedFail(xerr)
 			if xerr != nil {
 				return xerr

--- a/lib/server/resources/operations/installworker.go
+++ b/lib/server/resources/operations/installworker.go
@@ -1218,7 +1218,7 @@ func (w *worker) setReverseProxy(ctx context.Context) (ferr fail.Error) {
 
 			primaryGatewayVariables["ShortHostname"] = h.GetName()
 			domain := ""
-			xerr = h.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			xerr = h.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Inspect(hostproperty.DescriptionV1, func(clonable data.Clonable) fail.Error {
 					hostDescriptionV1, ok := clonable.(*propertiesv1.HostDescription)
 					if !ok {
@@ -1293,7 +1293,7 @@ func (w *worker) setReverseProxy(ctx context.Context) (ferr fail.Error) {
 
 				secondaryGatewayVariables["ShortHostname"] = h.GetName()
 				domain = ""
-				xerr = h.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+				xerr = h.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 					return props.Inspect(hostproperty.DescriptionV1, func(clonable data.Clonable) fail.Error {
 						hostDescriptionV1, ok := clonable.(*propertiesv1.HostDescription)
 						if !ok {

--- a/lib/server/resources/operations/installworker.go
+++ b/lib/server/resources/operations/installworker.go
@@ -179,7 +179,7 @@ func (w *worker) ConcernsCluster() bool {
 func (w *worker) CanProceed(ctx context.Context, s resources.FeatureSettings) fail.Error {
 	switch w.target.TargetType() {
 	case featuretargettype.Cluster:
-		xerr := w.validateContextForCluster()
+		xerr := w.validateContextForCluster(ctx)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr == nil && !s.SkipSizingRequirements {
 			xerr = w.validateClusterSizing(ctx)
@@ -1003,8 +1003,8 @@ func (w *worker) taskLaunchStep(task concurrency.Task, params concurrency.TaskPa
 // validateContextForCluster checks if the flavor of the cluster is listed in Feature specification
 // 'feature.suitableFor.cluster'.
 // If no flavors is listed, no flavors are authorized (but using 'cluster: no' is strongly recommended)
-func (w *worker) validateContextForCluster() fail.Error {
-	clusterFlavor, xerr := w.cluster.unsafeGetFlavor()
+func (w *worker) validateContextForCluster(ctx context.Context) fail.Error {
+	clusterFlavor, xerr := w.cluster.unsafeGetFlavor(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr
@@ -1045,7 +1045,7 @@ func (w *worker) validateContextForHost(settings resources.FeatureSettings) fail
 }
 
 func (w *worker) validateClusterSizing(ctx context.Context) (ferr fail.Error) {
-	clusterFlavor, xerr := w.cluster.unsafeGetFlavor()
+	clusterFlavor, xerr := w.cluster.unsafeGetFlavor(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr

--- a/lib/server/resources/operations/installworker.go
+++ b/lib/server/resources/operations/installworker.go
@@ -131,7 +131,7 @@ type worker struct {
 // newWorker ...
 // alterCmdCB is used to change the content of keys 'run' or 'package' before executing
 // the requested action. If not used, must be nil
-func newWorker(f resources.Feature, target resources.Targetable, method installmethod.Enum, action installaction.Enum, cb alterCommandCB) (*worker, fail.Error) {
+func newWorker(ctx context.Context, f resources.Feature, target resources.Targetable, method installmethod.Enum, action installaction.Enum, cb alterCommandCB) (*worker, fail.Error) {
 	w := worker{
 		feature:   f.(*Feature),
 		target:    target,
@@ -163,7 +163,7 @@ func newWorker(f resources.Feature, target resources.Targetable, method installm
 		if !f.(*Feature).Specs().IsSet(w.rootKey) {
 			msg := `syntax error in Feature '%s' specification file (%s):
 				no key '%s' found`
-			return nil, fail.SyntaxError(msg, f.GetName(), f.GetDisplayFilename(), w.rootKey)
+			return nil, fail.SyntaxError(msg, f.GetName(), f.GetDisplayFilename(ctx), w.rootKey)
 		}
 	}
 
@@ -644,7 +644,7 @@ func (w *worker) Proceed(ctx context.Context, params data.Map, settings resource
 		stepMap, ok := steps[strings.ToLower(k)].(map[string]interface{})
 		if !ok {
 			msg := `syntax error in Feature '%s' specification file (%s): no key '%s' found`
-			return outcomes, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(), stepKey)
+			return outcomes, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(nil), stepKey)
 		}
 
 		// Determine list of hosts concerned by the step
@@ -669,7 +669,7 @@ func (w *worker) Proceed(ctx context.Context, params data.Map, settings resource
 				}
 			} else {
 				msg := `syntax error in Feature '%s' specification file (%s): no key '%s.%s' found`
-				return nil, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(), stepKey, yamlTargetsKeyword)
+				return nil, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(nil), stepKey, yamlTargetsKeyword)
 			}
 
 			hostsList, xerr = w.identifyHosts(task.Context(), stepT)
@@ -889,7 +889,7 @@ func (w *worker) taskLaunchStep(task concurrency.Task, params concurrency.TaskPa
 		}
 	} else {
 		msg := `syntax error in Feature '%s' specification file (%s): no key '%s.%s' found`
-		return nil, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(), p.stepKey, yamlRunKeyword)
+		return nil, fail.SyntaxError(msg, w.feature.GetName(), w.feature.GetDisplayFilename(nil), p.stepKey, yamlRunKeyword)
 	}
 
 	wallTime := timings.HostLongOperationTimeout()

--- a/lib/server/resources/operations/kongctl.go
+++ b/lib/server/resources/operations/kongctl.go
@@ -97,7 +97,7 @@ func NewKongController(ctx context.Context, svc iaas.Service, subnet resources.S
 		}
 
 		if results.Successful() {
-			xerr = addressedGateway.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			xerr = addressedGateway.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Alter(hostproperty.FeaturesV1, func(clonable data.Clonable) fail.Error {
 					featuresV1, ok := clonable.(*propertiesv1.HostFeatures)
 					if !ok {

--- a/lib/server/resources/operations/kongctl.go
+++ b/lib/server/resources/operations/kongctl.go
@@ -74,7 +74,7 @@ func NewKongController(ctx context.Context, svc iaas.Service, subnet resources.S
 	}
 
 	var present bool
-	installedFeatures := addressedGateway.InstalledFeatures()
+	installedFeatures := addressedGateway.InstalledFeatures(ctx)
 	for _, v := range installedFeatures {
 		if v == "edgeproxy4subnet" || v == "reverseproxy" {
 			present = true
@@ -107,7 +107,7 @@ func NewKongController(ctx context.Context, svc iaas.Service, subnet resources.S
 					item := propertiesv1.NewHostInstalledFeature()
 					item.HostContext = true
 					var innerXErr fail.Error
-					item.Requires, innerXErr = featureInstance.Dependencies()
+					item.Requires, innerXErr = featureInstance.Dependencies(ctx)
 					if innerXErr != nil {
 						return innerXErr
 					}

--- a/lib/server/resources/operations/kongctl.go
+++ b/lib/server/resources/operations/kongctl.go
@@ -179,7 +179,7 @@ func (k *KongController) Apply(ctx context.Context, rule map[interface{}]interfa
 	var sourceControl map[string]interface{}
 
 	// Sets the values usable in all cases
-	xerr = k.subnet.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = k.subnet.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/metadatacore.go
+++ b/lib/server/resources/operations/metadatacore.go
@@ -808,7 +808,7 @@ func (myself *MetadataCore) unsafeReload() (ferr fail.Error) {
 }
 
 // BrowseFolder walks through MetadataFolder and executes a callback for each entry
-func (myself *MetadataCore) BrowseFolder(callback func(buf []byte) fail.Error) (ferr fail.Error) {
+func (myself *MetadataCore) BrowseFolder(ctx context.Context, callback func(buf []byte) fail.Error) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if valid.IsNil(myself) {

--- a/lib/server/resources/operations/metadatacore.go
+++ b/lib/server/resources/operations/metadatacore.go
@@ -410,7 +410,7 @@ func (myself *MetadataCore) updateIdentity() fail.Error {
 }
 
 // Read gets the data from Object Storage
-func (myself *MetadataCore) Read(ref string) (ferr fail.Error) {
+func (myself *MetadataCore) Read(ctx context.Context, ref string) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 	var xerr fail.Error
 
@@ -492,7 +492,7 @@ func (myself *MetadataCore) Read(ref string) (ferr fail.Error) {
 }
 
 // ReadByID reads a metadata identified by ID from Object Storage
-func (myself *MetadataCore) ReadByID(id string) (ferr fail.Error) {
+func (myself *MetadataCore) ReadByID(ctx context.Context, id string) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	// Note: do not test with .IsNull() here, it may be null value on first read

--- a/lib/server/resources/operations/metadatacore.go
+++ b/lib/server/resources/operations/metadatacore.go
@@ -703,7 +703,7 @@ func (myself *MetadataCore) write() fail.Error {
 }
 
 // Reload reloads the content from the Object Storage
-func (myself *MetadataCore) Reload() (ferr fail.Error) {
+func (myself *MetadataCore) Reload(context.Context) (ferr fail.Error) {
 	if valid.IsNil(myself) {
 		return fail.InvalidInstanceError()
 	}
@@ -946,7 +946,7 @@ func (myself *MetadataCore) Delete() (ferr fail.Error) {
 	return nil
 }
 
-func (myself *MetadataCore) Sdump() (_ string, ferr fail.Error) {
+func (myself *MetadataCore) Sdump(context.Context) (_ string, ferr fail.Error) {
 	if valid.IsNil(myself) {
 		return "", fail.InvalidInstanceError()
 	}

--- a/lib/server/resources/operations/metadatacore.go
+++ b/lib/server/resources/operations/metadatacore.go
@@ -217,7 +217,7 @@ func (myself *MetadataCore) Inspect(callback resources.Callback) (ferr fail.Erro
 // Review allows to access data contained in the instance, without reloading from the Object Storage; it's intended
 // to speed up operations that accept data is not up-to-date (for example, SSH configuration to access host should not
 // change through time).
-func (myself *MetadataCore) Review(callback resources.Callback) (ferr fail.Error) {
+func (myself *MetadataCore) Review(ctx context.Context, callback resources.Callback) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if valid.IsNil(myself) {
@@ -703,7 +703,7 @@ func (myself *MetadataCore) write() fail.Error {
 }
 
 // Reload reloads the content from the Object Storage
-func (myself *MetadataCore) Reload(context.Context) (ferr fail.Error) {
+func (myself *MetadataCore) Reload(ctx context.Context) (ferr fail.Error) {
 	if valid.IsNil(myself) {
 		return fail.InvalidInstanceError()
 	}
@@ -946,7 +946,7 @@ func (myself *MetadataCore) Delete() (ferr fail.Error) {
 	return nil
 }
 
-func (myself *MetadataCore) Sdump(context.Context) (_ string, ferr fail.Error) {
+func (myself *MetadataCore) Sdump(ctx context.Context) (_ string, ferr fail.Error) {
 	if valid.IsNil(myself) {
 		return "", fail.InvalidInstanceError()
 	}

--- a/lib/server/resources/operations/metadatacore.go
+++ b/lib/server/resources/operations/metadatacore.go
@@ -160,7 +160,7 @@ func (myself *MetadataCore) GetKind() string {
 }
 
 // Inspect protects the data for shared read
-func (myself *MetadataCore) Inspect(callback resources.Callback) (ferr fail.Error) {
+func (myself *MetadataCore) Inspect(ctx context.Context, callback resources.Callback) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 	var xerr fail.Error
 
@@ -1009,7 +1009,7 @@ func (myself *MetadataCore) unsafeSerialize() (_ []byte, ferr fail.Error) {
 }
 
 // Deserialize reads json code and reinstantiates
-func (myself *MetadataCore) Deserialize(buf []byte) (ferr fail.Error) {
+func (myself *MetadataCore) Deserialize(ctx context.Context, buf []byte) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if valid.IsNil(myself) {

--- a/lib/server/resources/operations/metadatacore.go
+++ b/lib/server/resources/operations/metadatacore.go
@@ -17,6 +17,7 @@
 package operations
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"sync"
@@ -240,7 +241,7 @@ func (myself *MetadataCore) Review(callback resources.Callback) (ferr fail.Error
 // Alter protects the data for exclusive write
 // Valid keyvalues for options are :
 // - "Reload": bool = allow disabling reloading from Object Storage if set to false (default is true)
-func (myself *MetadataCore) Alter(callback resources.Callback, options ...data.ImmutableKeyValue) (ferr fail.Error) {
+func (myself *MetadataCore) Alter(ctx context.Context, callback resources.Callback, options ...data.ImmutableKeyValue) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 	var xerr fail.Error
 

--- a/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
+++ b/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
@@ -772,6 +772,8 @@ func (tv toV21_05_0) upgradeClusterMetadataIfNeeded(instance *operations.Cluster
 		return fail.InvalidParameterCannotBeNilError("instance")
 	}
 
+	ctx := context.Background()
+
 	logrus.Tracef("Upgrading metadata of Cluster '%s'...", instance.GetName())
 
 	xerr := tv.upgradeClusterNodesPropertyIfNeeded(instance)
@@ -819,14 +821,14 @@ func (tv toV21_05_0) upgradeClusterMetadataIfNeeded(instance *operations.Cluster
 						return inErr
 					}
 
-					requires, inErr = feat.Dependencies()
+					requires, inErr = feat.Dependencies(ctx)
 					if inErr != nil {
 						return inErr
 					}
 
 					featuresV1.Installed[featName] = &propertiesv1.ClusterInstalledFeature{
 						Name:     featName,
-						FileName: feat.GetFilename(),
+						FileName: feat.GetFilename(ctx),
 						Requires: requires,
 					}
 					return nil
@@ -908,7 +910,8 @@ func (tv toV21_05_0) upgradeClusterMetadataIfNeeded(instance *operations.Cluster
 }
 
 func (tv toV21_05_0) addFeatureInProperties(feat resources.Feature, svc iaas.Service, hosts data.IndexedListOfStrings) fail.Error {
-	requires, xerr := feat.Dependencies()
+	ctx := context.Background()
+	requires, xerr := feat.Dependencies(ctx)
 	if xerr != nil {
 		return xerr
 	}
@@ -922,7 +925,7 @@ func (tv toV21_05_0) addFeatureInProperties(feat resources.Feature, svc iaas.Ser
 			continue
 		}
 
-		req, xerr := f.Dependencies()
+		req, xerr := f.Dependencies(ctx)
 		if xerr != nil {
 			logrus.Error(xerr.Error())
 			continue

--- a/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
+++ b/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
@@ -673,7 +673,7 @@ func (tv toV21_05_0) upgradeHostMetadataIfNeeded(instance *operations.Host) fail
 	}
 
 	// -- make sure SGs are applied to Host
-	isGateway, xerr := instance.IsGateway()
+	isGateway, xerr := instance.IsGateway(context.Background())
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr

--- a/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
+++ b/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
@@ -799,7 +799,7 @@ func (tv toV21_05_0) upgradeClusterMetadataIfNeeded(instance *operations.Cluster
 			return xerr
 		}
 
-		if flavor, flErr := instance.GetFlavor(nil); flErr == nil && flavor == clusterflavor.K8S {
+		if flavor, flErr := instance.GetFlavor(ctx); flErr == nil && flavor == clusterflavor.K8S {
 			var (
 				featName string
 				feat     resources.Feature
@@ -871,7 +871,7 @@ func (tv toV21_05_0) upgradeClusterMetadataIfNeeded(instance *operations.Cluster
 				}
 			}
 
-			netconf, inErr := instance.GetNetworkConfig(nil)
+			netconf, inErr := instance.GetNetworkConfig(ctx)
 			if inErr != nil {
 				return inErr
 			}
@@ -1109,7 +1109,7 @@ func (tv toV21_05_0) upgradeClusterNodesPropertyIfNeeded(instance *operations.Cl
 
 // upgradeClusterNetworkPropertyIfNeeded creates a clusterproperty.NetworkV3 property if previous versions are found
 func (tv toV21_05_0) upgradeClusterNetworkPropertyIfNeeded(instance *operations.Cluster) (bool, fail.Error) {
-	identity, xerr := instance.GetIdentity(nil)
+	identity, xerr := instance.GetIdentity(context.Background())
 	if xerr != nil {
 		return true, xerr
 	}

--- a/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
+++ b/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
@@ -797,7 +797,7 @@ func (tv toV21_05_0) upgradeClusterMetadataIfNeeded(instance *operations.Cluster
 			return xerr
 		}
 
-		if flavor, flErr := instance.GetFlavor(); flErr == nil && flavor == clusterflavor.K8S {
+		if flavor, flErr := instance.GetFlavor(nil); flErr == nil && flavor == clusterflavor.K8S {
 			var (
 				featName string
 				feat     resources.Feature
@@ -869,7 +869,7 @@ func (tv toV21_05_0) upgradeClusterMetadataIfNeeded(instance *operations.Cluster
 				}
 			}
 
-			netconf, inErr := instance.GetNetworkConfig()
+			netconf, inErr := instance.GetNetworkConfig(nil)
 			if inErr != nil {
 				return inErr
 			}
@@ -1106,7 +1106,7 @@ func (tv toV21_05_0) upgradeClusterNodesPropertyIfNeeded(instance *operations.Cl
 
 // upgradeClusterNetworkPropertyIfNeeded creates a clusterproperty.NetworkV3 property if previous versions are found
 func (tv toV21_05_0) upgradeClusterNetworkPropertyIfNeeded(instance *operations.Cluster) (bool, fail.Error) {
-	identity, xerr := instance.GetIdentity()
+	identity, xerr := instance.GetIdentity(nil)
 	if xerr != nil {
 		return true, xerr
 	}

--- a/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
+++ b/lib/server/resources/operations/metadatamaintenance/upgrade/tov21_05_0.go
@@ -738,7 +738,7 @@ func (tv toV21_05_0) upgradeHostMetadataIfNeeded(instance *operations.Host) fail
 	}
 
 	// We need to update cache information of Host before remotely execute a command, so reload metadata to trigger cache update
-	xerr = instance.Reload()
+	xerr = instance.Reload(nil)
 	if xerr != nil {
 		return xerr
 	}

--- a/lib/server/resources/operations/network.go
+++ b/lib/server/resources/operations/network.go
@@ -404,7 +404,7 @@ func (instance *Network) Delete(ctx context.Context) (ferr fail.Error) {
 		return fail.InvalidParameterCannotBeNilError("ctx")
 	}
 
-	xerr := instance.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		networkAbstract, ok := clonable.(*abstract.Network)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Network' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -427,7 +427,7 @@ func (instance *Network) Delete(ctx context.Context) (ferr fail.Error) {
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	tracer := debug.NewTracer(nil, true, "").WithStopwatch().Entering()
+	tracer := debug.NewTracer(ctx, true, "").WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	timings, xerr := instance.Service().Timings()
@@ -438,7 +438,7 @@ func (instance *Network) Delete(ctx context.Context) (ferr fail.Error) {
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		abstractNetwork, ok := clonable.(*abstract.Network)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Networking' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -612,7 +612,7 @@ func (instance *Network) Delete(ctx context.Context) (ferr fail.Error) {
 }
 
 // GetCIDR returns the CIDR of the subnet
-func (instance *Network) GetCIDR() (cidr string, ferr fail.Error) {
+func (instance *Network) GetCIDR(ctx context.Context) (cidr string, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -623,7 +623,7 @@ func (instance *Network) GetCIDR() (cidr string, ferr fail.Error) {
 	// defer instance.lock.RUnlock()
 
 	cidr = ""
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		an, ok := clonable.(*abstract.Network)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Networking' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -636,7 +636,7 @@ func (instance *Network) GetCIDR() (cidr string, ferr fail.Error) {
 }
 
 // ToProtocol converts resources.Network to protocol.Network
-func (instance *Network) ToProtocol() (out *protocol.Network, ferr fail.Error) {
+func (instance *Network) ToProtocol(ctx context.Context) (out *protocol.Network, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -646,7 +646,7 @@ func (instance *Network) ToProtocol() (out *protocol.Network, ferr fail.Error) {
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	xerr := instance.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		an, ok := clonable.(*abstract.Network)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Networking' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -727,7 +727,7 @@ func (instance *Network) AdoptSubnet(ctx context.Context, subnet resources.Subne
 		return fail.InvalidRequestError("cannot adopt Subnet '%s' because Network '%s' does not own it", subnet.GetName(), instance.GetName())
 	}
 
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(networkproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			nsV1, ok := clonable.(*propertiesv1.NetworkSubnets)
 			if !ok {
@@ -767,7 +767,7 @@ func (instance *Network) AbandonSubnet(ctx context.Context, subnetID string) (fe
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(networkproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			nsV1, ok := clonable.(*propertiesv1.NetworkSubnets)
 			if !ok {

--- a/lib/server/resources/operations/network.go
+++ b/lib/server/resources/operations/network.go
@@ -78,7 +78,7 @@ func LoadNetwork(ctx context.Context, svc iaas.Service, ref string, options ...d
 		return nil, fail.InvalidParameterError("ref", "cannot be empty string")
 	}
 
-	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onNetworkCacheMiss(svc, ref) }
+	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onNetworkCacheMiss(ctx, svc, ref) }
 	anon, xerr := cacheMissLoader()
 	if xerr != nil {
 		return nil, xerr
@@ -97,7 +97,7 @@ func LoadNetwork(ctx context.Context, svc iaas.Service, ref string, options ...d
 }
 
 // onNetworkCacheMiss is called when there is no instance in cache of Network 'ref'
-func onNetworkCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
+func onNetworkCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
 	networkInstance, innerXErr := NewNetwork(svc)
 	if innerXErr != nil {
 		return nil, innerXErr
@@ -112,7 +112,7 @@ func onNetworkCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.E
 		return nil, innerXErr
 	}
 
-	if strings.Compare(fail.IgnoreError(networkInstance.Sdump()).(string), fail.IgnoreError(blank.Sdump()).(string)) == 0 {
+	if strings.Compare(fail.IgnoreError(networkInstance.Sdump(ctx)).(string), fail.IgnoreError(blank.Sdump(ctx)).(string)) == 0 {
 		return nil, fail.NotFoundError("network with ref '%s' does NOT exist", ref)
 	}
 

--- a/lib/server/resources/operations/network.go
+++ b/lib/server/resources/operations/network.go
@@ -372,7 +372,7 @@ func (instance *Network) Browse(ctx context.Context, callback func(*abstract.Net
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.MetadataCore.BrowseFolder(func(buf []byte) fail.Error {
+	return instance.MetadataCore.BrowseFolder(ctx, func(buf []byte) fail.Error {
 		if task.Aborted() {
 			return fail.AbortedError(nil, "aborted")
 		}

--- a/lib/server/resources/operations/network.go
+++ b/lib/server/resources/operations/network.go
@@ -124,6 +124,10 @@ func (instance *Network) IsNull() bool {
 	return instance == nil || instance.MetadataCore == nil || valid.IsNil(instance.MetadataCore)
 }
 
+func (instance *Network) Exists() (bool, fail.Error) {
+	return true, nil
+}
+
 // Create creates a Network
 // returns:
 //   - *fail.ErrInvalidParameter: one parameter is invalid

--- a/lib/server/resources/operations/network.go
+++ b/lib/server/resources/operations/network.go
@@ -108,7 +108,7 @@ func onNetworkCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data
 		return nil, innerXErr
 	}
 
-	if innerXErr = networkInstance.Read(ref); innerXErr != nil {
+	if innerXErr = networkInstance.Read(ctx, ref); innerXErr != nil {
 		return nil, innerXErr
 	}
 

--- a/lib/server/resources/operations/network.go
+++ b/lib/server/resources/operations/network.go
@@ -438,7 +438,7 @@ func (instance *Network) Delete(ctx context.Context) (ferr fail.Error) {
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	xerr = instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		abstractNetwork, ok := clonable.(*abstract.Network)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Networking' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -727,7 +727,7 @@ func (instance *Network) AdoptSubnet(ctx context.Context, subnet resources.Subne
 		return fail.InvalidRequestError("cannot adopt Subnet '%s' because Network '%s' does not own it", subnet.GetName(), instance.GetName())
 	}
 
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(networkproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			nsV1, ok := clonable.(*propertiesv1.NetworkSubnets)
 			if !ok {
@@ -767,7 +767,7 @@ func (instance *Network) AbandonSubnet(ctx context.Context, subnetID string) (fe
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(networkproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			nsV1, ok := clonable.(*propertiesv1.NetworkSubnets)
 			if !ok {
@@ -790,8 +790,8 @@ func (instance *Network) AbandonSubnet(ctx context.Context, subnetID string) (fe
 }
 
 // FreeCIDRForSingleHost frees the CIDR index inside the Network 'Network'
-func FreeCIDRForSingleHost(network resources.Network, index uint) fail.Error {
-	return network.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+func FreeCIDRForSingleHost(ctx context.Context, network resources.Network, index uint) fail.Error {
+	return network.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(networkproperty.SingleHostsV1, func(clonable data.Clonable) fail.Error {
 			nshV1, ok := clonable.(*propertiesv1.NetworkSingleHosts)
 			if !ok {

--- a/lib/server/resources/operations/securitygroup.go
+++ b/lib/server/resources/operations/securitygroup.go
@@ -692,7 +692,7 @@ func (instance *SecurityGroup) Reset(ctx context.Context) (ferr fail.Error) {
 	// defer instance.lock.Unlock()
 
 	var rules abstract.SecurityGroupRules
-	xerr = instance.Inspect(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -880,7 +880,7 @@ func (instance *SecurityGroup) GetBoundHosts(ctx context.Context) (_ []*properti
 	// defer instance.lock.RUnlock()
 
 	var list []*propertiesv1.SecurityGroupBond
-	xerr = instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(securitygroupproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			sghV1, ok := clonable.(*propertiesv1.SecurityGroupHosts)
 			if !ok {
@@ -925,7 +925,7 @@ func (instance *SecurityGroup) GetBoundSubnets(ctx context.Context) (list []*pro
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	xerr = instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(securitygroupproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			sgnV1, ok := clonable.(*propertiesv1.SecurityGroupSubnets)
 			if !ok {
@@ -963,7 +963,7 @@ func (instance *SecurityGroup) ToProtocol(ctx context.Context) (_ *protocol.Secu
 	// defer instance.lock.RUnlock()
 
 	out := &protocol.SecurityGroupResponse{}
-	return out, instance.Inspect(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return out, instance.Inspect(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/securitygroup.go
+++ b/lib/server/resources/operations/securitygroup.go
@@ -138,6 +138,10 @@ func (instance *SecurityGroup) IsNull() bool {
 	return valid.IsNil(instance.MetadataCore)
 }
 
+func (instance *SecurityGroup) Exists() (bool, fail.Error) {
+	return true, nil
+}
+
 // Carry overloads rv.core.Carry() to add Volume to service cache
 func (instance *SecurityGroup) carry(ctx context.Context, clonable data.Clonable) (ferr fail.Error) {
 	if instance == nil {

--- a/lib/server/resources/operations/securitygroup.go
+++ b/lib/server/resources/operations/securitygroup.go
@@ -118,7 +118,7 @@ func onSGCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Iden
 		return nil, innerXerr
 	}
 
-	if innerXErr = sgInstance.Read(ref); innerXErr != nil {
+	if innerXErr = sgInstance.Read(ctx, ref); innerXErr != nil {
 		return nil, innerXErr
 	}
 

--- a/lib/server/resources/operations/securitygroup.go
+++ b/lib/server/resources/operations/securitygroup.go
@@ -122,7 +122,7 @@ func onSGCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Error)
 		return nil, innerXErr
 	}
 
-	if strings.Compare(fail.IgnoreError(sgInstance.Sdump()).(string), fail.IgnoreError(blank.Sdump()).(string)) == 0 {
+	if strings.Compare(fail.IgnoreError(sgInstance.Sdump(nil)).(string), fail.IgnoreError(blank.Sdump(nil)).(string)) == 0 {
 		return nil, fail.NotFoundError("security group with ref '%s' does NOT exist", ref)
 	}
 

--- a/lib/server/resources/operations/securitygroup.go
+++ b/lib/server/resources/operations/securitygroup.go
@@ -88,7 +88,7 @@ func LoadSecurityGroup(ctx context.Context, svc iaas.Service, ref string, option
 		return nil, fail.InvalidParameterError("ref", "cannot be empty string")
 	}
 
-	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onSGCacheMiss(svc, ref) }
+	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onSGCacheMiss(ctx, svc, ref) }
 	anon, xerr := cacheMissLoader()
 	if xerr != nil {
 		return nil, xerr
@@ -107,7 +107,7 @@ func LoadSecurityGroup(ctx context.Context, svc iaas.Service, ref string, option
 }
 
 // onSGCacheMiss is called when there is no instance in cache of Security Group 'ref'
-func onSGCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
+func onSGCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
 	sgInstance, innerXErr := NewSecurityGroup(svc)
 	if innerXErr != nil {
 		return nil, innerXErr
@@ -122,7 +122,7 @@ func onSGCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Error)
 		return nil, innerXErr
 	}
 
-	if strings.Compare(fail.IgnoreError(sgInstance.Sdump(nil)).(string), fail.IgnoreError(blank.Sdump(nil)).(string)) == 0 {
+	if strings.Compare(fail.IgnoreError(sgInstance.Sdump(ctx)).(string), fail.IgnoreError(blank.Sdump(ctx)).(string)) == 0 {
 		return nil, fail.NotFoundError("security group with ref '%s' does NOT exist", ref)
 	}
 
@@ -330,7 +330,7 @@ func (instance *SecurityGroup) Create(ctx context.Context, networkID, name, desc
 	}()
 
 	if len(rules) == 0 {
-		xerr = instance.unsafeClear()
+		xerr = instance.unsafeClear(ctx)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr != nil {
 			return xerr
@@ -597,7 +597,7 @@ func (instance *SecurityGroup) unbindFromSubnets(ctx context.Context, in *proper
 					}
 				}
 
-				xerr = subnetInstance.Review(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+				xerr = subnetInstance.Review(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 					return inspectFunc(props)
 				})
 				if xerr != nil {
@@ -664,7 +664,7 @@ func (instance *SecurityGroup) Clear(ctx context.Context) (ferr fail.Error) {
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.unsafeClear()
+	return instance.unsafeClear(ctx)
 }
 
 // Reset clears a security group and re-adds associated rules as stored in metadata
@@ -707,7 +707,7 @@ func (instance *SecurityGroup) Reset(ctx context.Context) (ferr fail.Error) {
 	}
 
 	// Removes all rules...
-	xerr = instance.unsafeClear()
+	xerr = instance.unsafeClear(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return xerr
@@ -715,7 +715,7 @@ func (instance *SecurityGroup) Reset(ctx context.Context) (ferr fail.Error) {
 
 	// ... then re-adds rules from metadata
 	for _, v := range rules {
-		xerr = instance.unsafeAddRule(v)
+		xerr = instance.unsafeAddRule(ctx, v)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr != nil {
 			return xerr
@@ -745,7 +745,7 @@ func (instance *SecurityGroup) AddRule(ctx context.Context, rule *abstract.Secur
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	return instance.unsafeAddRule(rule)
+	return instance.unsafeAddRule(ctx, rule)
 }
 
 // AddRules adds rules to a Security Group
@@ -775,7 +775,7 @@ func (instance *SecurityGroup) AddRules(ctx context.Context, rules abstract.Secu
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -835,7 +835,7 @@ func (instance *SecurityGroup) DeleteRule(ctx context.Context, rule *abstract.Se
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -952,7 +952,7 @@ func (instance *SecurityGroup) CheckConsistency(_ context.Context) fail.Error {
 }
 
 // ToProtocol converts a Security Group to protobuf message
-func (instance *SecurityGroup) ToProtocol() (_ *protocol.SecurityGroupResponse, ferr fail.Error) {
+func (instance *SecurityGroup) ToProtocol(ctx context.Context) (_ *protocol.SecurityGroupResponse, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if valid.IsNil(instance) {
@@ -1024,7 +1024,7 @@ func (instance *SecurityGroup) UnbindFromHost(ctx context.Context, hostInstance 
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			sgphV1, ok := clonable.(*propertiesv1.SecurityGroupHosts)
 			if !ok {
@@ -1078,7 +1078,7 @@ func (instance *SecurityGroup) UnbindFromHostByReference(ctx context.Context, ho
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			sgphV1, ok := clonable.(*propertiesv1.SecurityGroupHosts)
 			if !ok {
@@ -1144,7 +1144,7 @@ func (instance *SecurityGroup) BindToSubnet(ctx context.Context, subnetInstance 
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	xerr = subnetInstance.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = subnetInstance.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var subnetHosts *propertiesv1.SubnetHosts
 		innerXErr := props.Inspect(subnetproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			var ok bool
@@ -1172,7 +1172,7 @@ func (instance *SecurityGroup) BindToSubnet(ctx context.Context, subnetInstance 
 		return xerr
 	}
 
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		if mark == resources.MarkSecurityGroupAsDefault {
 			asg, ok := clonable.(*abstract.SecurityGroup)
 			if !ok {
@@ -1313,7 +1313,7 @@ func (instance *SecurityGroup) UnbindFromSubnet(ctx context.Context, subnetInsta
 	// defer instance.lock.Unlock()
 
 	var subnetHosts *propertiesv1.SubnetHosts
-	xerr = subnetInstance.Review(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = subnetInstance.Review(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(subnetproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			var ok bool
 			subnetHosts, ok = clonable.(*propertiesv1.SubnetHosts)
@@ -1366,7 +1366,7 @@ func (instance *SecurityGroup) unbindFromSubnetHosts(ctx context.Context, params
 	}
 
 	// -- Remove Hosts attached to Subnet referenced in Security Group
-	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			sghV1, ok := clonable.(*propertiesv1.SecurityGroupHosts)
 			if !ok {
@@ -1386,7 +1386,7 @@ func (instance *SecurityGroup) unbindFromSubnetHosts(ctx context.Context, params
 	}
 
 	// -- Remove Subnet referenced in Security Group
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			sgsV1, ok := clonable.(*propertiesv1.SecurityGroupSubnets)
 			if !ok {
@@ -1439,7 +1439,7 @@ func (instance *SecurityGroup) UnbindFromSubnetByReference(ctx context.Context, 
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			sgsV1, ok := clonable.(*propertiesv1.SecurityGroupSubnets)
 			if !ok {

--- a/lib/server/resources/operations/securitygroup.go
+++ b/lib/server/resources/operations/securitygroup.go
@@ -192,7 +192,7 @@ func (instance *SecurityGroup) Browse(ctx context.Context, callback func(*abstra
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.MetadataCore.BrowseFolder(func(buf []byte) fail.Error {
+	return instance.MetadataCore.BrowseFolder(ctx, func(buf []byte) fail.Error {
 		asg := abstract.NewSecurityGroup()
 		xerr = asg.Deserialize(buf)
 		xerr = debug.InjectPlannedFail(xerr)

--- a/lib/server/resources/operations/securitygroup.go
+++ b/lib/server/resources/operations/securitygroup.go
@@ -363,7 +363,7 @@ func (instance *SecurityGroup) Create(ctx context.Context, networkID, name, desc
 			return xerr
 		}
 
-		xerr = networkInstance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+		xerr = networkInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 			return updateFunc(props)
 		})
 		if xerr != nil {
@@ -775,7 +775,7 @@ func (instance *SecurityGroup) AddRules(ctx context.Context, rules abstract.Secu
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -835,7 +835,7 @@ func (instance *SecurityGroup) DeleteRule(ctx context.Context, rule *abstract.Se
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1024,7 +1024,7 @@ func (instance *SecurityGroup) UnbindFromHost(ctx context.Context, hostInstance 
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			sgphV1, ok := clonable.(*propertiesv1.SecurityGroupHosts)
 			if !ok {
@@ -1078,7 +1078,7 @@ func (instance *SecurityGroup) UnbindFromHostByReference(ctx context.Context, ho
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			sgphV1, ok := clonable.(*propertiesv1.SecurityGroupHosts)
 			if !ok {
@@ -1172,7 +1172,7 @@ func (instance *SecurityGroup) BindToSubnet(ctx context.Context, subnetInstance 
 		return xerr
 	}
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		if mark == resources.MarkSecurityGroupAsDefault {
 			asg, ok := clonable.(*abstract.SecurityGroup)
 			if !ok {
@@ -1366,7 +1366,7 @@ func (instance *SecurityGroup) unbindFromSubnetHosts(ctx context.Context, params
 	}
 
 	// -- Remove Hosts attached to Subnet referenced in Security Group
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			sghV1, ok := clonable.(*propertiesv1.SecurityGroupHosts)
 			if !ok {
@@ -1386,7 +1386,7 @@ func (instance *SecurityGroup) unbindFromSubnetHosts(ctx context.Context, params
 	}
 
 	// -- Remove Subnet referenced in Security Group
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			sgsV1, ok := clonable.(*propertiesv1.SecurityGroupSubnets)
 			if !ok {
@@ -1439,7 +1439,7 @@ func (instance *SecurityGroup) UnbindFromSubnetByReference(ctx context.Context, 
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			sgsV1, ok := clonable.(*propertiesv1.SecurityGroupSubnets)
 			if !ok {

--- a/lib/server/resources/operations/securitygrouptasks.go
+++ b/lib/server/resources/operations/securitygrouptasks.go
@@ -74,7 +74,7 @@ func (instance *SecurityGroup) taskUnbindFromHost(
 	}
 
 	// Updates host metadata regarding Security Groups
-	xerr = hostInstance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = hostInstance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.SecurityGroupsV1, func(clonable data.Clonable) fail.Error {
 			hsgV1, ok := clonable.(*propertiesv1.HostSecurityGroups)
 			if !ok {

--- a/lib/server/resources/operations/securitygrouptasks.go
+++ b/lib/server/resources/operations/securitygrouptasks.go
@@ -59,6 +59,7 @@ func (instance *SecurityGroup) taskUnbindFromHost(
 	}
 
 	sgID := instance.GetID()
+	ctx := task.Context()
 
 	// Unbind Security Group from Host on provider side
 	xerr := instance.Service().UnbindSecurityGroupFromHost(sgID, hostInstance.GetID())
@@ -74,7 +75,7 @@ func (instance *SecurityGroup) taskUnbindFromHost(
 	}
 
 	// Updates host metadata regarding Security Groups
-	xerr = hostInstance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = hostInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.SecurityGroupsV1, func(clonable data.Clonable) fail.Error {
 			hsgV1, ok := clonable.(*propertiesv1.HostSecurityGroups)
 			if !ok {

--- a/lib/server/resources/operations/securitygroupunsafe.go
+++ b/lib/server/resources/operations/securitygroupunsafe.go
@@ -62,7 +62,7 @@ func (instance *SecurityGroup) unsafeDelete(ctx context.Context, force bool) fai
 		networkID = castedValue.ID
 	}
 
-	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var ok bool
 		abstractSG, ok = clonable.(*abstract.SecurityGroup)
 		if !ok {
@@ -214,8 +214,8 @@ func (instance *SecurityGroup) updateNetworkMetadataOnRemoval(ctx context.Contex
 
 // unsafeClear is the non goroutine-safe implementation for Clear, that does the real work faster (no locking, less if no parameter validations)
 // Note: must be used wisely
-func (instance *SecurityGroup) unsafeClear() fail.Error {
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+func (instance *SecurityGroup) unsafeClear(ctx context.Context) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -227,7 +227,7 @@ func (instance *SecurityGroup) unsafeClear() fail.Error {
 }
 
 // unsafeAddRule adds a rule to a security group
-func (instance *SecurityGroup) unsafeAddRule(rule *abstract.SecurityGroupRule) (ferr fail.Error) {
+func (instance *SecurityGroup) unsafeAddRule(ctx context.Context, rule *abstract.SecurityGroupRule) (ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	xerr := rule.Validate()
@@ -235,7 +235,7 @@ func (instance *SecurityGroup) unsafeAddRule(rule *abstract.SecurityGroupRule) (
 		return xerr
 	}
 
-	return instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -279,7 +279,7 @@ func (instance *SecurityGroup) unsafeUnbindFromSubnet(ctx context.Context, param
 	}
 
 	// Update instance metadata
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			sgsV1, ok := clonable.(*propertiesv1.SecurityGroupSubnets)
 			if !ok {
@@ -347,7 +347,7 @@ func (instance *SecurityGroup) unsafeBindToSubnet(ctx context.Context, abstractS
 		return xerr
 	}
 
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		if mark == resources.MarkSecurityGroupAsDefault {
 			asg, ok := clonable.(*abstract.SecurityGroup)
 			if !ok {
@@ -400,7 +400,7 @@ func (instance *SecurityGroup) unsafeBindToHost(ctx context.Context, hostInstanc
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		if mark == resources.MarkSecurityGroupAsDefault {
 			asg, ok := clonable.(*abstract.SecurityGroup)
 			if !ok {

--- a/lib/server/resources/operations/securitygroupunsafe.go
+++ b/lib/server/resources/operations/securitygroupunsafe.go
@@ -62,7 +62,7 @@ func (instance *SecurityGroup) unsafeDelete(ctx context.Context, force bool) fai
 		networkID = castedValue.ID
 	}
 
-	xerr = instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var ok bool
 		abstractSG, ok = clonable.(*abstract.SecurityGroup)
 		if !ok {
@@ -198,7 +198,7 @@ func (instance *SecurityGroup) updateNetworkMetadataOnRemoval(ctx context.Contex
 		return xerr
 	}
 
-	return networkInstance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return networkInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(networkproperty.SecurityGroupsV1, func(clonable data.Clonable) fail.Error {
 			nsgV1, ok := clonable.(*propertiesv1.NetworkSecurityGroups)
 			if !ok {
@@ -215,7 +215,7 @@ func (instance *SecurityGroup) updateNetworkMetadataOnRemoval(ctx context.Contex
 // unsafeClear is the non goroutine-safe implementation for Clear, that does the real work faster (no locking, less if no parameter validations)
 // Note: must be used wisely
 func (instance *SecurityGroup) unsafeClear() fail.Error {
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -235,7 +235,7 @@ func (instance *SecurityGroup) unsafeAddRule(rule *abstract.SecurityGroupRule) (
 		return xerr
 	}
 
-	return instance.Alter(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		asg, ok := clonable.(*abstract.SecurityGroup)
 		if !ok {
 			return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -279,7 +279,7 @@ func (instance *SecurityGroup) unsafeUnbindFromSubnet(ctx context.Context, param
 	}
 
 	// Update instance metadata
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			sgsV1, ok := clonable.(*propertiesv1.SecurityGroupSubnets)
 			if !ok {
@@ -347,7 +347,7 @@ func (instance *SecurityGroup) unsafeBindToSubnet(ctx context.Context, abstractS
 		return xerr
 	}
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		if mark == resources.MarkSecurityGroupAsDefault {
 			asg, ok := clonable.(*abstract.SecurityGroup)
 			if !ok {
@@ -400,7 +400,7 @@ func (instance *SecurityGroup) unsafeBindToHost(ctx context.Context, hostInstanc
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		if mark == resources.MarkSecurityGroupAsDefault {
 			asg, ok := clonable.(*abstract.SecurityGroup)
 			if !ok {

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -180,7 +180,7 @@ func onShareCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.I
 		return nil, innerXErr
 	}
 
-	if innerXErr = shareInstance.Read(ref); innerXErr != nil {
+	if innerXErr = shareInstance.Read(ctx, ref); innerXErr != nil {
 		return nil, innerXErr
 	}
 

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -392,7 +392,7 @@ func (instance *Share) Create(
 	}
 
 	// Nothing will be changed in instance, but we do not want more than 1 goroutine to install NFS if needed
-	xerr = server.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = server.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 			serverSharesV1, ok := clonable.(*propertiesv1.HostShares)
 			if !ok {
@@ -470,7 +470,7 @@ func (instance *Share) Create(
 
 	// Updates Host Property propertiesv1.HostShares
 	var hostShare *propertiesv1.HostShare
-	xerr = server.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = server.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 			serverSharesV1, ok := clonable.(*propertiesv1.HostShares)
 			if !ok {
@@ -503,7 +503,7 @@ func (instance *Share) Create(
 	defer func() {
 		ferr = debug.InjectPlannedFail(ferr)
 		if ferr != nil {
-			derr := server.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			derr := server.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Alter(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 					serverSharesV1, ok := clonable.(*propertiesv1.HostShares)
 					if !ok {
@@ -781,7 +781,7 @@ func (instance *Share) Mount(ctx context.Context, target resources.Host, spath s
 	}
 
 	// -- Mount the Share on host --
-	xerr = rhServer.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = rhServer.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 			hostSharesV1, ok := clonable.(*propertiesv1.HostShares)
 			if !ok {
@@ -835,7 +835,7 @@ func (instance *Share) Mount(ctx context.Context, target resources.Host, spath s
 	defer func() {
 		ferr = debug.InjectPlannedFail(ferr)
 		if ferr != nil {
-			derr := rhServer.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			derr := rhServer.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Alter(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 					hostSharesV1, ok := clonable.(*propertiesv1.HostShares)
 					if !ok {
@@ -867,7 +867,7 @@ func (instance *Share) Mount(ctx context.Context, target resources.Host, spath s
 	}()
 
 	var mount *propertiesv1.HostRemoteMount
-	xerr = target.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = target.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			targetMountsV1, ok := clonable.(*propertiesv1.HostMounts)
 			if !ok {
@@ -1011,7 +1011,7 @@ func (instance *Share) Unmount(ctx context.Context, target resources.Host) (ferr
 	var mountPath string
 	remotePath := serverPrivateIP + ":" + hostShare.Path
 	targetID := target.GetID()
-	xerr = target.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = target.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			targetMountsV1, ok := clonable.(*propertiesv1.HostMounts)
 			if !ok {
@@ -1053,7 +1053,7 @@ func (instance *Share) Unmount(ctx context.Context, target resources.Host) (ferr
 	}
 
 	// Remove host from client lists of the Share
-	xerr = rhServer.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = rhServer.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 			hostSharesV1, ok := clonable.(*propertiesv1.HostShares)
 			if !ok {
@@ -1137,7 +1137,7 @@ func (instance *Share) Delete(ctx context.Context) (ferr fail.Error) {
 		return fail.InvalidRequestError(fmt.Sprintf("cannot delete share on '%s', '%s' is NOT started", targetName, targetName))
 	}
 
-	xerr = objserver.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = objserver.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 			hostSharesV1, ok := clonable.(*propertiesv1.HostShares)
 			if !ok {

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -315,7 +315,7 @@ func (instance *Share) Create(
 	targetName := server.GetName()
 
 	var state hoststate.Enum
-	state, xerr = server.GetState()
+	state, xerr = server.GetState(ctx)
 	if xerr != nil {
 		return xerr
 	}
@@ -653,7 +653,7 @@ func (instance *Share) Mount(ctx context.Context, target resources.Host, spath s
 	targetName = target.GetName()
 
 	var state hoststate.Enum
-	state, xerr = target.GetState()
+	state, xerr = target.GetState(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -950,7 +950,7 @@ func (instance *Share) Unmount(ctx context.Context, target resources.Host) (ferr
 	targetName := target.GetName()
 
 	var state hoststate.Enum
-	state, xerr = target.GetState()
+	state, xerr = target.GetState(ctx)
 	if xerr != nil {
 		return xerr
 	}
@@ -1128,7 +1128,7 @@ func (instance *Share) Delete(ctx context.Context) (ferr fail.Error) {
 	targetName := objserver.GetName()
 
 	var state hoststate.Enum
-	state, xerr = objserver.GetState()
+	state, xerr = objserver.GetState(ctx)
 	if xerr != nil {
 		return xerr
 	}

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -345,7 +345,7 @@ func (instance *Share) Create(
 	}
 
 	// -- make some validations --
-	xerr = server.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = server.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		// Check if the path to Share isn't a remote mount or contains a remote mount
 		return props.Inspect(hostproperty.MountsV1, func(clonable data.Clonable) fail.Error {
 			serverMountsV1, ok := clonable.(*propertiesv1.HostMounts)
@@ -690,7 +690,7 @@ func (instance *Share) Mount(ctx context.Context, target resources.Host, spath s
 		return nil, xerr
 	}
 
-	xerr = rhServer.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = rhServer.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 			hostSharesV1, ok := clonable.(*propertiesv1.HostShares)
 			if !ok {
@@ -726,7 +726,7 @@ func (instance *Share) Mount(ctx context.Context, target resources.Host, spath s
 
 	// Lock for read, won't change data other than properties, which are protected by their own way
 	targetID = target.GetID()
-	xerr = target.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = target.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		// Check if Share is already mounted
 		// Check if there is already volume mounted in the path (or in subpath)
 		innerXErr := props.Inspect(hostproperty.MountsV1, func(clonable data.Clonable) fail.Error {
@@ -988,7 +988,7 @@ func (instance *Share) Unmount(ctx context.Context, target resources.Host) (ferr
 		return xerr
 	}
 
-	xerr = rhServer.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = rhServer.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 			rhServer, ok := clonable.(*propertiesv1.HostShares)
 			if !ok {

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -325,7 +325,7 @@ func (instance *Share) Create(
 	}
 
 	// Check if a Share already exists with the same name
-	_, xerr = server.GetShare(shareName)
+	_, xerr = server.GetShare(ctx, shareName)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		switch xerr.(type) {
@@ -1234,7 +1234,7 @@ func (instance *Share) ToProtocol(ctx context.Context) (_ *protocol.ShareMountLi
 		return nil, xerr
 	}
 
-	share, xerr := server.GetShare(shareID)
+	share, xerr := server.GetShare(ctx, shareID)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -1260,7 +1260,7 @@ func (instance *Share) ToProtocol(ctx context.Context) (_ *protocol.ShareMountLi
 			continue
 		}
 
-		mounts, xerr := h.GetMounts()
+		mounts, xerr := h.GetMounts(ctx)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr != nil {
 			logrus.Errorf(xerr.Error())

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -541,7 +541,7 @@ func (instance *Share) unsafeGetServer(ctx context.Context) (_ resources.Host, f
 	}
 
 	var hostID, hostName string
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		share, ok := clonable.(*ShareIdentity)
 		if !ok {
 			return fail.InconsistentError("'*shareItem' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -583,7 +583,7 @@ func (instance *Share) GetServer(ctx context.Context) (_ resources.Host, ferr fa
 	// defer instance.lock.RUnlock()
 
 	var hostID, hostName string
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		share, ok := clonable.(*ShareIdentity)
 		if !ok {
 			return fail.InconsistentError("'*shareItem' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -663,7 +663,7 @@ func (instance *Share) Mount(ctx context.Context, target resources.Host, spath s
 	}
 
 	// Retrieve info about the Share
-	xerr = instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		si, ok := clonable.(*ShareIdentity)
 		if !ok {
 			return fail.InconsistentError("'*shareItem' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -960,7 +960,7 @@ func (instance *Share) Unmount(ctx context.Context, target resources.Host) (ferr
 	}
 
 	// Retrieve info about the Share
-	xerr = instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		si, ok := clonable.(*ShareIdentity)
 		if !ok {
 			return fail.InconsistentError("'*shareItem' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1104,7 +1104,7 @@ func (instance *Share) Delete(ctx context.Context) (ferr fail.Error) {
 
 	// -- Retrieve info about the Share --
 	// Note: we do not use GetName() and ID() to avoid 2 consecutive instance.Inspect()
-	xerr = instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		si, ok := clonable.(*ShareIdentity)
 		if !ok {
 			return fail.InconsistentError("'*shareItem' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -196,6 +196,10 @@ func (instance *Share) IsNull() bool {
 	return instance == nil || instance.MetadataCore == nil || valid.IsNil(instance.MetadataCore)
 }
 
+func (instance *Share) Exists() (bool, fail.Error) {
+	return true, nil
+}
+
 // carry creates metadata and add Volume to service cache
 func (instance *Share) carry(ctx context.Context, clonable data.Clonable) (ferr fail.Error) {
 	if instance == nil {

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -250,7 +250,7 @@ func (instance *Share) Browse(ctx context.Context, callback func(string, string)
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.MetadataCore.BrowseFolder(func(buf []byte) fail.Error {
+	return instance.MetadataCore.BrowseFolder(ctx, func(buf []byte) fail.Error {
 		if task.Aborted() {
 			return fail.AbortedError(nil, "aborted")
 		}

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -150,7 +150,7 @@ func LoadShare(ctx context.Context, svc iaas.Service, ref string, options ...dat
 		return nil, fail.InvalidParameterError("ref", "cannot be empty string")
 	}
 
-	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onShareCacheMiss(svc, ref) }
+	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onShareCacheMiss(ctx, svc, ref) }
 	anon, xerr := cacheMissLoader()
 	if xerr != nil {
 		return nil, xerr
@@ -169,7 +169,7 @@ func LoadShare(ctx context.Context, svc iaas.Service, ref string, options ...dat
 }
 
 // onShareCacheMiss is called when there is no instance in cache of Share 'ref'
-func onShareCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
+func onShareCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
 	shareInstance, innerXErr := NewShare(svc)
 	if innerXErr != nil {
 		return nil, innerXErr
@@ -184,7 +184,7 @@ func onShareCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Err
 		return nil, innerXErr
 	}
 
-	if strings.Compare(fail.IgnoreError(shareInstance.Sdump()).(string), fail.IgnoreError(blank.Sdump()).(string)) == 0 {
+	if strings.Compare(fail.IgnoreError(shareInstance.Sdump(ctx)).(string), fail.IgnoreError(blank.Sdump(ctx)).(string)) == 0 {
 		return nil, fail.NotFoundError("share with ref '%s' does NOT exist", ref)
 	}
 

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -1545,7 +1545,7 @@ func (instance *Subnet) GetEndpointIP(ctx context.Context) (ip string, ferr fail
 }
 
 // HasVirtualIP tells if the Subnet uses a VIP a default route
-func (instance *Subnet) HasVirtualIP() (bool, fail.Error) {
+func (instance *Subnet) HasVirtualIP(context.Context) (bool, fail.Error) {
 	if instance == nil || valid.IsNil(instance) {
 		return false, fail.InvalidInstanceError()
 	}
@@ -1571,7 +1571,7 @@ func (instance *Subnet) GetVirtualIP() (vip *abstract.VirtualIP, ferr fail.Error
 }
 
 // GetCIDR returns the CIDR of the Subnet
-func (instance *Subnet) GetCIDR() (cidr string, ferr fail.Error) {
+func (instance *Subnet) GetCIDR(context.Context) (cidr string, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -1585,7 +1585,7 @@ func (instance *Subnet) GetCIDR() (cidr string, ferr fail.Error) {
 }
 
 // GetState returns the current state of the Subnet
-func (instance *Subnet) GetState() (state subnetstate.Enum, ferr fail.Error) {
+func (instance *Subnet) GetState(context.Context) (state subnetstate.Enum, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -189,7 +189,7 @@ func LoadSubnet(ctx context.Context, svc iaas.Service, networkRef, subnetRef str
 
 		if networkInstance != nil { // nolint
 			// Network metadata loaded, find the ID of the Subnet (subnetRef may be ID or Name)
-			xerr = networkInstance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			xerr = networkInstance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Inspect(networkproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 					subnetsV1, ok := clonable.(*propertiesv1.NetworkSubnets)
 					if !ok {
@@ -677,7 +677,7 @@ func (instance *Subnet) validateNetwork(ctx context.Context, req *abstract.Subne
 			}
 		}
 	} else {
-		xerr = networkInstance.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+		xerr = networkInstance.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 			var ok bool
 			an, ok = clonable.(*abstract.Network)
 			if !ok {
@@ -805,7 +805,7 @@ func (instance *Subnet) AttachHost(ctx context.Context, host resources.Host) (fe
 	hostName := host.GetName()
 
 	// To apply the request, the instance must be one of the Subnets of the Host
-	xerr = host.Inspect(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = host.Inspect(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(hostproperty.NetworkV2, func(clonable data.Clonable) fail.Error {
 			hnV2, ok := clonable.(*propertiesv2.HostNetworking)
 			if !ok {
@@ -1158,7 +1158,7 @@ func (instance *Subnet) Delete(ctx context.Context) (ferr fail.Error) {
 
 	svc := instance.Service()
 	subnetName := instance.GetName()
-	xerr = instance.Inspect(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Inspect(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1792,7 +1792,7 @@ func (instance *Subnet) ListSecurityGroups(ctx context.Context, state securitygr
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return list, instance.Inspect(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return list, instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(subnetproperty.SecurityGroupsV1, func(clonable data.Clonable) fail.Error {
 			ssgV1, ok := clonable.(*propertiesv1.SubnetSecurityGroups)
 			if !ok {
@@ -1862,7 +1862,7 @@ func (instance *Subnet) EnableSecurityGroup(ctx context.Context, sgInstance reso
 			}
 
 			var asg *abstract.SecurityGroup
-			innerXErr := sgInstance.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+			innerXErr := sgInstance.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 				var ok bool
 				if asg, ok = clonable.(*abstract.SecurityGroup); !ok {
 					return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1979,7 +1979,7 @@ func (instance *Subnet) DisableSecurityGroup(ctx context.Context, sgInstance res
 			}
 
 			var abstractSG *abstract.SecurityGroup
-			innerXErr := sgInstance.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+			innerXErr := sgInstance.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 				var ok bool
 				if abstractSG, ok = clonable.(*abstract.SecurityGroup); !ok {
 					return fail.InconsistentError("'*abstract.SecurityGroup' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -752,7 +752,7 @@ func (instance *Subnet) Browse(ctx context.Context, callback func(*abstract.Subn
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.MetadataCore.BrowseFolder(func(buf []byte) fail.Error {
+	return instance.MetadataCore.BrowseFolder(ctx, func(buf []byte) fail.Error {
 		if task.Aborted() {
 			return fail.AbortedError(nil, "aborted")
 		}

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -291,7 +291,7 @@ func (instance *Subnet) updateCachedInformation(ctx context.Context) fail.Error 
 	defer instance.localCache.Unlock()
 
 	var primaryGatewayID, secondaryGatewayID string
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -462,7 +462,7 @@ func (instance *Subnet) CreateSecurityGroups(ctx context.Context, networkInstanc
 
 // bindInternalSecurityGroupToGateway does what its name says
 func (instance *Subnet) bindInternalSecurityGroupToGateway(ctx context.Context, host resources.Host) fail.Error {
-	return instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	return instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -486,7 +486,7 @@ func (instance *Subnet) undoBindInternalSecurityGroupToGateway(ctx context.Conte
 	// FIXME: Use ctx the right way
 
 	if xerr != nil && *xerr != nil && keepOnFailure {
-		_ = instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+		_ = instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 			task, cerr := concurrency.TaskFromContextOrVoid(ctx)
 			cerr = debug.InjectPlannedFail(cerr)
 			if cerr != nil {
@@ -830,7 +830,7 @@ func (instance *Subnet) AttachHost(ctx context.Context, host resources.Host) (fe
 		return xerr
 	}
 
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		subnetAbstract, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -913,13 +913,13 @@ func (instance *Subnet) DetachHost(ctx context.Context, hostID string) (ferr fai
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	tracer := debug.NewTracer(nil, tracing.ShouldTrace("resources.subnet"), "('"+hostID+"')").Entering()
+	tracer := debug.NewTracer(ctx, tracing.ShouldTrace("resources.subnet"), "('"+hostID+"')").Entering()
 	defer tracer.Exiting()
 
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return instance.unsafeAbandonHost(props, hostID)
 	})
 }
@@ -951,7 +951,7 @@ func (instance *Subnet) ListHosts(ctx context.Context) (_ []resources.Host, ferr
 	// defer instance.lock.RUnlock()
 
 	var list []resources.Host
-	xerr = instance.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Inspect(subnetproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			shV1, ok := clonable.(*propertiesv1.SubnetHosts)
 			if !ok {
@@ -998,7 +998,7 @@ func (instance *Subnet) GetGatewayPublicIP(ctx context.Context, primary bool) (_
 
 	var ip string
 	svc := instance.Service()
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1050,7 +1050,7 @@ func (instance *Subnet) GetGatewayPublicIPs(ctx context.Context) (_ []string, fe
 	// defer instance.lock.RUnlock()
 
 	var gatewayIPs []string
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1122,7 +1122,7 @@ func (instance *Subnet) Delete(ctx context.Context) (ferr fail.Error) {
 		subnetAbstract *abstract.Subnet
 		subnetHosts    *propertiesv1.SubnetHosts
 	)
-	xerr = instance.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var ok bool
 		subnetAbstract, ok = clonable.(*abstract.Subnet)
 		if !ok {
@@ -1149,7 +1149,7 @@ func (instance *Subnet) Delete(ctx context.Context) (ferr fail.Error) {
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	tracer := debug.NewTracer(nil, true /*tracing.ShouldTrace("operations.Subnet")*/).WithStopwatch().Entering()
+	tracer := debug.NewTracer(ctx, true /*tracing.ShouldTrace("operations.Subnet")*/).WithStopwatch().Entering()
 	defer tracer.Exiting()
 
 	// Lock Subnet instance
@@ -1211,7 +1211,7 @@ func (instance *Subnet) Delete(ctx context.Context) (ferr fail.Error) {
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1355,7 +1355,7 @@ func (instance *Subnet) InspectNetwork(ctx context.Context) (rn resources.Networ
 	}
 
 	var as *abstract.Subnet
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		var ok bool
 		as, ok = clonable.(*abstract.Subnet)
 		if !ok {
@@ -1522,7 +1522,7 @@ func (instance *Subnet) GetEndpointIP(ctx context.Context) (ip string, ferr fail
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1545,7 +1545,7 @@ func (instance *Subnet) GetEndpointIP(ctx context.Context) (ip string, ferr fail
 }
 
 // HasVirtualIP tells if the Subnet uses a VIP a default route
-func (instance *Subnet) HasVirtualIP(context.Context) (bool, fail.Error) {
+func (instance *Subnet) HasVirtualIP(ctx context.Context) (bool, fail.Error) {
 	if instance == nil || valid.IsNil(instance) {
 		return false, fail.InvalidInstanceError()
 	}
@@ -1553,11 +1553,11 @@ func (instance *Subnet) HasVirtualIP(context.Context) (bool, fail.Error) {
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.unsafeHasVirtualIP()
+	return instance.unsafeHasVirtualIP(ctx)
 }
 
 // GetVirtualIP returns an abstract.VirtualIP used by gateway HA
-func (instance *Subnet) GetVirtualIP() (vip *abstract.VirtualIP, ferr fail.Error) {
+func (instance *Subnet) GetVirtualIP(ctx context.Context) (vip *abstract.VirtualIP, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -1567,11 +1567,11 @@ func (instance *Subnet) GetVirtualIP() (vip *abstract.VirtualIP, ferr fail.Error
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.unsafeGetVirtualIP()
+	return instance.unsafeGetVirtualIP(ctx)
 }
 
 // GetCIDR returns the CIDR of the Subnet
-func (instance *Subnet) GetCIDR(context.Context) (cidr string, ferr fail.Error) {
+func (instance *Subnet) GetCIDR(ctx context.Context) (cidr string, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -1581,11 +1581,11 @@ func (instance *Subnet) GetCIDR(context.Context) (cidr string, ferr fail.Error) 
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.unsafeGetCIDR()
+	return instance.unsafeGetCIDR(ctx)
 }
 
 // GetState returns the current state of the Subnet
-func (instance *Subnet) GetState(context.Context) (state subnetstate.Enum, ferr fail.Error) {
+func (instance *Subnet) GetState(ctx context.Context) (state subnetstate.Enum, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if instance == nil || valid.IsNil(instance) {
@@ -1595,7 +1595,7 @@ func (instance *Subnet) GetState(context.Context) (state subnetstate.Enum, ferr 
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.unsafeGetState()
+	return instance.unsafeGetState(ctx)
 }
 
 // ToProtocol converts resources.Network to protocol.Network
@@ -1640,13 +1640,13 @@ func (instance *Subnet) ToProtocol(ctx context.Context) (_ *protocol.Subnet, fer
 	pn := &protocol.Subnet{
 		Id:         instance.GetID(),
 		Name:       instance.GetName(),
-		Cidr:       func() string { out, _ := instance.unsafeGetCIDR(); return out }(),
+		Cidr:       func() string { out, _ := instance.unsafeGetCIDR(ctx); return out }(),
 		GatewayIds: gwIDs,
-		Failover:   func() bool { out, _ := instance.unsafeHasVirtualIP(); return out }(),
-		State:      protocol.SubnetState(func() int32 { out, _ := instance.unsafeGetState(); return int32(out) }()),
+		Failover:   func() bool { out, _ := instance.unsafeHasVirtualIP(ctx); return out }(),
+		State:      protocol.SubnetState(func() int32 { out, _ := instance.unsafeGetState(ctx); return int32(out) }()),
 	}
 
-	vip, xerr = instance.unsafeGetVirtualIP()
+	vip, xerr = instance.unsafeGetVirtualIP(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		if _, ok := xerr.(*fail.ErrNotFound); !ok || valid.IsNil(xerr) {
@@ -1690,7 +1690,7 @@ func (instance *Subnet) BindSecurityGroup(ctx context.Context, sgInstance resour
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		abstractSubnet, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1836,7 +1836,7 @@ func (instance *Subnet) EnableSecurityGroup(ctx context.Context, sgInstance reso
 	// defer instance.lock.Unlock()
 
 	svc := instance.Service()
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		abstractSubnet, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1953,7 +1953,7 @@ func (instance *Subnet) DisableSecurityGroup(ctx context.Context, sgInstance res
 	// defer instance.lock.Unlock()
 
 	svc := instance.Service()
-	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		abstractSubnet, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -2042,7 +2042,7 @@ func (instance *Subnet) InspectGatewaySecurityGroup(ctx context.Context) (_ reso
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -2068,7 +2068,7 @@ func (instance *Subnet) InspectInternalSecurityGroup(ctx context.Context) (_ res
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -2094,7 +2094,7 @@ func (instance *Subnet) InspectPublicIPSecurityGroup(ctx context.Context) (_ res
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -273,7 +273,7 @@ func onSubnetCacheMiss(ctx context.Context, svc iaas.Service, subnetID string) (
 		return nil, innerXErr
 	}
 
-	if innerXErr = subnetInstance.Read(subnetID); innerXErr != nil {
+	if innerXErr = subnetInstance.Read(ctx, subnetID); innerXErr != nil {
 		return nil, innerXErr
 	}
 

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -830,7 +830,7 @@ func (instance *Subnet) AttachHost(ctx context.Context, host resources.Host) (fe
 		return xerr
 	}
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		subnetAbstract, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -919,7 +919,7 @@ func (instance *Subnet) DetachHost(ctx context.Context, hostID string) (ferr fai
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return instance.unsafeAbandonHost(props, hostID)
 	})
 }
@@ -1211,7 +1211,7 @@ func (instance *Subnet) Delete(ctx context.Context) (ferr fail.Error) {
 		return fail.AbortedError(nil, "aborted")
 	}
 
-	xerr = instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1262,7 +1262,7 @@ func (instance *Subnet) Delete(ctx context.Context) (ferr fail.Error) {
 				return innerXErr
 			}
 
-			innerXErr = FreeCIDRForSingleHost(networkInstance, as.SingleHostCIDRIndex)
+			innerXErr = FreeCIDRForSingleHost(ctx, networkInstance, as.SingleHostCIDRIndex)
 			if innerXErr != nil {
 				return innerXErr
 			}
@@ -1690,7 +1690,7 @@ func (instance *Subnet) BindSecurityGroup(ctx context.Context, sgInstance resour
 	// instance.lock.Lock()
 	// defer instance.lock.Unlock()
 
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		abstractSubnet, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1836,7 +1836,7 @@ func (instance *Subnet) EnableSecurityGroup(ctx context.Context, sgInstance reso
 	// defer instance.lock.Unlock()
 
 	svc := instance.Service()
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		abstractSubnet, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1953,7 +1953,7 @@ func (instance *Subnet) DisableSecurityGroup(ctx context.Context, sgInstance res
 	// defer instance.lock.Unlock()
 
 	svc := instance.Service()
-	return instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		abstractSubnet, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -356,6 +356,10 @@ func (instance *Subnet) IsNull() bool {
 	return instance == nil || (instance != nil && ((instance.MetadataCore == nil) || (instance.MetadataCore != nil && valid.IsNil(instance.MetadataCore))))
 }
 
+func (instance *Subnet) Exists() (bool, fail.Error) {
+	return true, nil
+}
+
 // Carry wraps rv.core.Carry() to add Volume to service cache
 func (instance *Subnet) Carry(ctx context.Context, clonable data.Clonable) (ferr fail.Error) {
 	if clonable == nil {

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -858,7 +858,7 @@ func (instance *Subnet) AttachHost(ctx context.Context, host resources.Host) (fe
 			}
 		}
 
-		isGateway, innerXErr := host.IsGateway()
+		isGateway, innerXErr := host.IsGateway(ctx)
 		if innerXErr != nil {
 			return innerXErr
 		}

--- a/lib/server/resources/operations/subnettasks.go
+++ b/lib/server/resources/operations/subnettasks.go
@@ -85,7 +85,7 @@ func (instance *Subnet) taskCreateGateway(task concurrency.Task, params concurre
 	// Set link to Subnet before testing if Host has been successfully created;
 	// in case of failure, we need to have registered the gateway ID in Subnet in case KeepOnFailure is requested, to
 	// be able to delete subnet on later safescale command
-	xerr = instance.Alter(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -135,7 +135,7 @@ func (instance *Subnet) taskCreateGateway(task concurrency.Task, params concurre
 				}
 				_ = ferr.AddConsequence(derr)
 			} else {
-				xerr = rgw.Alter(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+				xerr = rgw.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 					as, ok := clonable.(*abstract.HostCore)
 					if !ok {
 						return fail.InconsistentError("'*abstract.HostCore' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/subnetunsafe.go
+++ b/lib/server/resources/operations/subnetunsafe.go
@@ -78,7 +78,7 @@ func (instance *Subnet) unsafeInspectGateway(ctx context.Context, primary bool) 
 // unsafeGetDefaultRouteIP ...
 func (instance *Subnet) unsafeGetDefaultRouteIP(ctx context.Context) (ip string, ferr fail.Error) {
 	ip = ""
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -108,10 +108,10 @@ func (instance *Subnet) unsafeGetDefaultRouteIP(ctx context.Context) (ip string,
 }
 
 // unsafeGetVirtualIP returns an abstract.VirtualIP used by gateway HA
-func (instance *Subnet) unsafeGetVirtualIP() (vip *abstract.VirtualIP, ferr fail.Error) {
+func (instance *Subnet) unsafeGetVirtualIP(ctx context.Context) (vip *abstract.VirtualIP, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
-	xerr := instance.Review(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -134,9 +134,9 @@ func (instance *Subnet) unsafeGetVirtualIP() (vip *abstract.VirtualIP, ferr fail
 
 // unsafeGetCIDR returns the CIDR of the network
 // Intended to be used when instance is notoriously not nil (because previously checked)
-func (instance *Subnet) unsafeGetCIDR() (cidr string, ferr fail.Error) {
+func (instance *Subnet) unsafeGetCIDR(ctx context.Context) (cidr string, ferr fail.Error) {
 	cidr = ""
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -150,8 +150,8 @@ func (instance *Subnet) unsafeGetCIDR() (cidr string, ferr fail.Error) {
 
 // unsafeGetState returns the state of the network
 // Intended to be used when rs is notoriously not null (because previously checked)
-func (instance *Subnet) unsafeGetState() (state subnetstate.Enum, ferr fail.Error) {
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+func (instance *Subnet) unsafeGetState(ctx context.Context) (state subnetstate.Enum, ferr fail.Error) {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -182,9 +182,9 @@ func (instance *Subnet) unsafeAbandonHost(props *serialize.JSONProperties, hostI
 }
 
 // unsafeHasVirtualIP tells if the Subnet uses a VIP a default route
-func (instance *Subnet) unsafeHasVirtualIP() (bool, fail.Error) {
+func (instance *Subnet) unsafeHasVirtualIP(ctx context.Context) (bool, fail.Error) {
 	var found bool
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -432,7 +432,7 @@ func (instance *Subnet) createInternalSecurityGroup(
 ) (_ resources.SecurityGroup, ferr fail.Error) {
 	sgName := fmt.Sprintf(subnetInternalSecurityGroupNamePattern, instance.GetName(), networkName)
 
-	cidr, xerr := instance.unsafeGetCIDR()
+	cidr, xerr := instance.unsafeGetCIDR(ctx)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -619,7 +619,7 @@ func (instance *Subnet) unsafeCreateSubnet(ctx context.Context, req abstract.Sub
 		}()
 	}
 
-	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -710,7 +710,7 @@ func (instance *Subnet) unsafeUpdateSubnetStatus(ctx context.Context, target sub
 		return xerr
 	}
 
-	xerr = instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -728,7 +728,7 @@ func (instance *Subnet) unsafeUpdateSubnetStatus(ctx context.Context, target sub
 }
 
 func (instance *Subnet) unsafeFinalizeSubnetCreation(ctx context.Context) fail.Error {
-	xerr := instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Alter(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -829,7 +829,7 @@ func (instance *Subnet) unsafeCreateGateways(ctx context.Context, req abstract.S
 	}
 
 	var as *abstract.Subnet
-	xerr = instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		var ok bool
 		as, ok = clonable.(*abstract.Subnet)
 		if !ok {
@@ -1119,7 +1119,7 @@ func (instance *Subnet) unsafeCreateGateways(ctx context.Context, req abstract.S
 	}
 
 	// As hosts are marked as gateways, the configuration stopped on phase 2 'netsec', the remaining 3 phases have to be run explicitly
-	xerr = instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1192,7 +1192,7 @@ func (instance *Subnet) unsafeUnbindSecurityGroup(ctx context.Context, sgInstanc
 	defer tracer.Exiting()
 
 	// -- Unbind Security Group from Subnet and attached Hosts
-	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var subnetHosts *propertiesv1.SubnetHosts
 		innerXErr := props.Inspect(subnetproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			var ok bool

--- a/lib/server/resources/operations/subnetunsafe.go
+++ b/lib/server/resources/operations/subnetunsafe.go
@@ -619,7 +619,7 @@ func (instance *Subnet) unsafeCreateSubnet(ctx context.Context, req abstract.Sub
 		}()
 	}
 
-	xerr = instance.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -662,7 +662,7 @@ func (instance *Subnet) unsafeCreateSubnet(ctx context.Context, req abstract.Sub
 	}
 
 	// attach Subnet to Network
-	xerr = networkInstance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = networkInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(networkproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			nsV1, ok := clonable.(*propertiesv1.NetworkSubnets)
 			if !ok {
@@ -682,7 +682,7 @@ func (instance *Subnet) unsafeCreateSubnet(ctx context.Context, req abstract.Sub
 	// Starting from here, remove Subnet from Network metadata if exiting with error
 	defer func() {
 		if ferr != nil && !req.KeepOnFailure {
-			derr := networkInstance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+			derr := networkInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 				return props.Alter(networkproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 					nsV1, ok := clonable.(*propertiesv1.NetworkSubnets)
 					if !ok {
@@ -710,7 +710,7 @@ func (instance *Subnet) unsafeUpdateSubnetStatus(ctx context.Context, target sub
 		return xerr
 	}
 
-	xerr = instance.Alter(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -728,7 +728,7 @@ func (instance *Subnet) unsafeUpdateSubnetStatus(ctx context.Context, target sub
 }
 
 func (instance *Subnet) unsafeFinalizeSubnetCreation(ctx context.Context) fail.Error {
-	xerr := instance.Alter(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1119,7 +1119,7 @@ func (instance *Subnet) unsafeCreateGateways(ctx context.Context, req abstract.S
 	}
 
 	// As hosts are marked as gateways, the configuration stopped on phase 2 'netsec', the remaining 3 phases have to be run explicitly
-	xerr = instance.Alter(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -1192,7 +1192,7 @@ func (instance *Subnet) unsafeUnbindSecurityGroup(ctx context.Context, sgInstanc
 	defer tracer.Exiting()
 
 	// -- Unbind Security Group from Subnet and attached Hosts
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var subnetHosts *propertiesv1.SubnetHosts
 		innerXErr := props.Inspect(subnetproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			var ok bool
@@ -1248,7 +1248,7 @@ func (instance *Subnet) unsafeUnbindSecurityGroup(ctx context.Context, sgInstanc
 	}
 
 	// -- Remove Subnet reference in Security Group
-	return sgInstance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return sgInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.SubnetsV1, func(clonable data.Clonable) fail.Error {
 			sgsV1, ok := clonable.(*propertiesv1.SecurityGroupSubnets)
 			if !ok {

--- a/lib/server/resources/operations/subnetunsafe.go
+++ b/lib/server/resources/operations/subnetunsafe.go
@@ -1060,7 +1060,7 @@ func (instance *Subnet) unsafeCreateGateways(ctx context.Context, req abstract.S
 	}
 
 	// Update userdata of gateway(s)
-	xerr = instance.Inspect(func(clonable data.Clonable, _ *serialize.JSONProperties) (innerXErr fail.Error) {
+	xerr = instance.Inspect(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) (innerXErr fail.Error) {
 		as, ok := clonable.(*abstract.Subnet)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Subnet' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -252,7 +252,7 @@ func (instance *volume) Browse(ctx context.Context, callback func(*abstract.Volu
 	// instance.lock.RLock()
 	// defer instance.lock.RUnlock()
 
-	return instance.MetadataCore.BrowseFolder(func(buf []byte) fail.Error {
+	return instance.MetadataCore.BrowseFolder(ctx, func(buf []byte) fail.Error {
 		if task.Aborted() {
 			return fail.AbortedError(nil, "aborted")
 		}

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -117,7 +117,7 @@ func onVolumeCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.
 		return nil, innerXErr
 	}
 
-	if innerXErr = volumeInstance.Read(ref); innerXErr != nil {
+	if innerXErr = volumeInstance.Read(ctx, ref); innerXErr != nil {
 		return nil, innerXErr
 	}
 

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -87,7 +87,7 @@ func LoadVolume(ctx context.Context, svc iaas.Service, ref string, options ...da
 		return nil, fail.InvalidParameterCannotBeEmptyStringError("ref")
 	}
 
-	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onVolumeCacheMiss(svc, ref) }
+	cacheMissLoader := func() (data.Identifiable, fail.Error) { return onVolumeCacheMiss(ctx, svc, ref) }
 	anon, xerr := cacheMissLoader()
 	if xerr != nil {
 		return nil, xerr
@@ -106,7 +106,7 @@ func LoadVolume(ctx context.Context, svc iaas.Service, ref string, options ...da
 }
 
 // onVolumeCacheMiss is called when there is no instance in cache of Volume 'ref'
-func onVolumeCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
+func onVolumeCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Identifiable, fail.Error) {
 	volumeInstance, innerXErr := NewVolume(svc)
 	if innerXErr != nil {
 		return nil, innerXErr
@@ -121,7 +121,7 @@ func onVolumeCacheMiss(svc iaas.Service, ref string) (data.Identifiable, fail.Er
 		return nil, innerXErr
 	}
 
-	if strings.Compare(fail.IgnoreError(volumeInstance.Sdump()).(string), fail.IgnoreError(blank.Sdump()).(string)) == 0 {
+	if strings.Compare(fail.IgnoreError(volumeInstance.Sdump(ctx)).(string), fail.IgnoreError(blank.Sdump(ctx)).(string)) == 0 {
 		return nil, fail.NotFoundError("volume with ref '%s' does NOT exist", ref)
 	}
 

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -162,7 +162,7 @@ func (instance *volume) carry(ctx context.Context, clonable data.Clonable) (ferr
 }
 
 // GetSpeed ...
-func (instance *volume) GetSpeed() (_ volumespeed.Enum, ferr fail.Error) {
+func (instance *volume) GetSpeed(context.Context) (_ volumespeed.Enum, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if valid.IsNil(instance) {
@@ -176,7 +176,7 @@ func (instance *volume) GetSpeed() (_ volumespeed.Enum, ferr fail.Error) {
 }
 
 // GetSize ...
-func (instance *volume) GetSize() (_ int, ferr fail.Error) {
+func (instance *volume) GetSize(context.Context) (_ int, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	if valid.IsNil(instance) {
@@ -190,7 +190,7 @@ func (instance *volume) GetSize() (_ int, ferr fail.Error) {
 }
 
 // GetAttachments returns where the Volume is attached
-func (instance *volume) GetAttachments() (_ *propertiesv1.VolumeAttachments, ferr fail.Error) {
+func (instance *volume) GetAttachments(context.Context) (_ *propertiesv1.VolumeAttachments, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 	var xerr fail.Error
 
@@ -1207,7 +1207,7 @@ func (instance *volume) ToProtocol(ctx context.Context) (*protocol.VolumeInspect
 		Attachments: []*protocol.VolumeAttachmentResponse{},
 	}
 
-	attachments, xerr := instance.GetAttachments()
+	attachments, xerr := instance.GetAttachments(nil)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -548,7 +548,7 @@ func (instance *volume) Attach(ctx context.Context, host resources.Host, path, f
 	}
 
 	var state hoststate.Enum
-	state, xerr = host.GetState()
+	state, xerr = host.GetState(ctx)
 	if xerr != nil {
 		return xerr
 	}
@@ -972,7 +972,7 @@ func (instance *volume) Detach(ctx context.Context, host resources.Host) (ferr f
 	targetName := host.GetName()
 
 	var state hoststate.Enum
-	state, xerr = host.GetState()
+	state, xerr = host.GetState(ctx)
 	if xerr != nil {
 		return xerr
 	}

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -133,6 +133,10 @@ func (instance *volume) IsNull() bool {
 	return instance == nil || instance.MetadataCore == nil || valid.IsNil(instance.MetadataCore)
 }
 
+func (instance *volume) Exists() (bool, fail.Error) {
+	return true, nil
+}
+
 // carry overloads rv.core.Carry() to add Volume to service cache
 func (instance *volume) carry(ctx context.Context, clonable data.Clonable) (ferr fail.Error) {
 	if instance == nil {

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -1207,7 +1207,7 @@ func (instance *volume) ToProtocol(ctx context.Context) (*protocol.VolumeInspect
 		Attachments: []*protocol.VolumeAttachmentResponse{},
 	}
 
-	attachments, xerr := instance.GetAttachments(nil)
+	attachments, xerr := instance.GetAttachments(ctx)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -698,7 +698,7 @@ func (instance *volume) Attach(ctx context.Context, host resources.Host, path, f
 	}
 
 	// -- updates target properties --
-	xerr = host.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = host.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		innerXErr := props.Alter(hostproperty.VolumesV1, func(clonable data.Clonable) (ferr fail.Error) {
 			hostVolumesV1, ok := clonable.(*propertiesv1.HostVolumes)
 			if !ok {
@@ -806,7 +806,7 @@ func (instance *volume) Attach(ctx context.Context, host resources.Host, path, f
 					_ = ferr.AddConsequence(fail.Wrap(derr, "cleaning up on %s, failed to unmount Volume '%s' from Host '%s'", ActionFromError(ferr), volumeName, targetName))
 				}
 			}
-			derr := host.Alter(func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
+			derr := host.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 				innerXErr := props.Alter(hostproperty.VolumesV1, func(clonable data.Clonable) fail.Error {
 					hostVolumesV1, ok := clonable.(*propertiesv1.HostVolumes)
 					if !ok {
@@ -847,7 +847,7 @@ func (instance *volume) Attach(ctx context.Context, host resources.Host, path, f
 	defer task.DisarmAbortSignal()()
 
 	// Updates volume properties
-	xerr = instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	xerr = instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(volumeproperty.AttachedV1, func(clonable data.Clonable) fail.Error {
 			volumeAttachedV1, ok := clonable.(*propertiesv1.VolumeAttachments)
 			if !ok {
@@ -1001,7 +1001,7 @@ func (instance *volume) Detach(ctx context.Context, host resources.Host) (ferr f
 	svc := instance.Service()
 
 	// -- Update target attachments --
-	return host.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+	return host.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		var (
 			attachment *propertiesv1.HostVolume
 			mount      *propertiesv1.HostLocalMount
@@ -1174,7 +1174,7 @@ func (instance *volume) Detach(ctx context.Context, host resources.Host) (ferr f
 		}
 
 		// ... and finish with update of volume property propertiesv1.VolumeAttachments
-		return instance.Alter(func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
+		return instance.Alter(nil, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 			return props.Alter(volumeproperty.AttachedV1, func(clonable data.Clonable) fail.Error {
 				volumeAttachedV1, ok := clonable.(*propertiesv1.VolumeAttachments)
 				if !ok {

--- a/lib/server/resources/operations/volumeunsafe.go
+++ b/lib/server/resources/operations/volumeunsafe.go
@@ -17,6 +17,7 @@
 package operations
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/CS-SI/SafeScale/v22/lib/server/resources/abstract"
@@ -29,9 +30,9 @@ import (
 
 // unsafeGetSpeed ...
 // Intended to be used when instance is notoriously not nil
-func (instance *volume) unsafeGetSpeed() (volumespeed.Enum, fail.Error) {
+func (instance *volume) unsafeGetSpeed(ctx context.Context) (volumespeed.Enum, fail.Error) {
 	var speed volumespeed.Enum
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		av, ok := clonable.(*abstract.Volume)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Volume' expected, '%s' provided", reflect.TypeOf(clonable).String())
@@ -50,9 +51,9 @@ func (instance *volume) unsafeGetSpeed() (volumespeed.Enum, fail.Error) {
 
 // unsafeGetSize ...
 // Intended to be used when instance is notoriously not nil
-func (instance *volume) unsafeGetSize() (int, fail.Error) {
+func (instance *volume) unsafeGetSize(ctx context.Context) (int, fail.Error) {
 	var size int
-	xerr := instance.Review(func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
+	xerr := instance.Review(ctx, func(clonable data.Clonable, _ *serialize.JSONProperties) fail.Error {
 		av, ok := clonable.(*abstract.Volume)
 		if !ok {
 			return fail.InconsistentError("'*abstract.Volume' expected, '%s' provided", reflect.TypeOf(clonable).String())

--- a/lib/server/resources/securitygroup.go
+++ b/lib/server/resources/securitygroup.go
@@ -66,7 +66,7 @@ type SecurityGroup interface {
 	GetBoundHosts(ctx context.Context) ([]*propertiesv1.SecurityGroupBond, fail.Error)                             // returns a slice of bonds corresponding to hosts bound to the security group
 	GetBoundSubnets(ctx context.Context) ([]*propertiesv1.SecurityGroupBond, fail.Error)                           // returns a slice of bonds corresponding to networks bound to the security group
 	Reset(ctx context.Context) fail.Error                                                                          // resets the rules of the security group from the ones registered in metadata
-	ToProtocol() (*protocol.SecurityGroupResponse, fail.Error)                                                     // converts a SecurityGroup to equivalent gRPC message
+	ToProtocol(ctx context.Context) (*protocol.SecurityGroupResponse, fail.Error)                                  // converts a SecurityGroup to equivalent gRPC message
 	UnbindFromHost(ctx context.Context, _ Host) fail.Error                                                         // unbinds a Security Group from Host
 	UnbindFromHostByReference(ctx context.Context, _ string) fail.Error                                            // unbinds a Security Group from Host
 	UnbindFromSubnet(ctx context.Context, _ Subnet) fail.Error                                                     // unbinds a Security Group from Subnet

--- a/lib/server/resources/securitygroup.go
+++ b/lib/server/resources/securitygroup.go
@@ -52,6 +52,7 @@ type SecurityGroup interface {
 	Metadata
 	data.Identifiable
 	observer.Observable
+	Consistent
 
 	AddRule(ctx context.Context, _ *abstract.SecurityGroupRule) fail.Error                                         // returns true if the host is member of a cluster
 	AddRules(ctx context.Context, _ abstract.SecurityGroupRules) fail.Error                                        // returns true if the host is member of a cluster

--- a/lib/server/resources/share.go
+++ b/lib/server/resources/share.go
@@ -33,6 +33,7 @@ type Share interface {
 	Metadata
 	data.Identifiable
 	observer.Observable
+	Consistent
 
 	Browse(ctx context.Context, callback func(hostName string, shareID string) fail.Error) fail.Error
 	Create(ctx context.Context, shareName string, host Host, path string, options string /*securityModes []string, readOnly, rootSquash, secure, async, noHide, crossMount, subtreeCheck bool*/) fail.Error // creates a share on host

--- a/lib/server/resources/subnet.go
+++ b/lib/server/resources/subnet.go
@@ -37,6 +37,7 @@ type Subnet interface {
 	Metadata
 	data.Identifiable
 	observer.Observable
+	Consistent
 
 	DetachHost(ctx context.Context, hostID string) fail.Error                                                                    // unlinks host ID from subnet
 	AttachHost(ctx context.Context, _ Host) fail.Error                                                                           // links Host to the Subnet

--- a/lib/server/resources/subnet.go
+++ b/lib/server/resources/subnet.go
@@ -51,9 +51,9 @@ type Subnet interface {
 	GetGatewayPublicIPs(ctx context.Context) ([]string, fail.Error)                                                              // returns the gateway IPs of the Subnet
 	GetDefaultRouteIP(ctx context.Context) (string, fail.Error)                                                                  // returns the private IP of the default route of the Subnet
 	GetEndpointIP(ctx context.Context) (string, fail.Error)                                                                      // returns the public IP to reach the Subnet from Internet
-	GetCIDR() (string, fail.Error)                                                                                               // return the CIDR
-	GetState() (subnetstate.Enum, fail.Error)                                                                                    // gives the current state of the Subnet
-	HasVirtualIP() (bool, fail.Error)                                                                                            // tells if the Subnet is using a VIP as default route
+	GetCIDR(ctx context.Context) (string, fail.Error)                                                                            // return the CIDR
+	GetState(ctx context.Context) (subnetstate.Enum, fail.Error)                                                                 // gives the current state of the Subnet
+	HasVirtualIP(ctx context.Context) (bool, fail.Error)                                                                         // tells if the Subnet is using a VIP as default route
 	InspectGateway(ctx context.Context, primary bool) (Host, fail.Error)                                                         // returns the gateway related to Subnet
 	InspectGatewaySecurityGroup(ctx context.Context) (SecurityGroup, fail.Error)                                                 // returns the SecurityGroup responsible of network security on Gateway
 	InspectInternalSecurityGroup(ctx context.Context) (SecurityGroup, fail.Error)                                                // returns the SecurityGroup responsible of internal network security

--- a/lib/server/resources/volume.go
+++ b/lib/server/resources/volume.go
@@ -35,6 +35,7 @@ type Volume interface {
 	Metadata
 	data.Identifiable
 	observer.Observable
+	Consistent
 
 	Attach(ctx context.Context, host Host, path, format string, doNotFormat, doNotMount bool) fail.Error // attaches a volume to a host
 	Browse(ctx context.Context, callback func(*abstract.Volume) fail.Error) fail.Error                   // walks through all the metadata objects in network

--- a/lib/server/resources/volume.go
+++ b/lib/server/resources/volume.go
@@ -42,8 +42,8 @@ type Volume interface {
 	Create(ctx context.Context, req abstract.VolumeRequest) fail.Error                                   // creates a volume
 	Delete(ctx context.Context) fail.Error                                                               // deletes a volume
 	Detach(ctx context.Context, host Host) fail.Error                                                    // detaches the volume identified by ref, ref can be the name or the id
-	GetAttachments() (*propertiesv1.VolumeAttachments, fail.Error)                                       // returns the property containing where the volume is attached
-	GetSize() (int, fail.Error)                                                                          // returns the size of volume in GB
-	GetSpeed() (volumespeed.Enum, fail.Error)                                                            // returns the speed of the volume (more or less the type of hardware)
+	GetAttachments(ctx context.Context) (*propertiesv1.VolumeAttachments, fail.Error)                    // returns the property containing where the volume is attached
+	GetSize(ctx context.Context) (int, fail.Error)                                                       // returns the size of volume in GB
+	GetSpeed(ctx context.Context) (volumespeed.Enum, fail.Error)                                         // returns the speed of the volume (more or less the type of hardware)
 	ToProtocol(ctx context.Context) (*protocol.VolumeInspectResponse, fail.Error)                        // converts volume to equivalent protocol message
 }

--- a/lib/system/ssh.go
+++ b/lib/system/ssh.go
@@ -162,7 +162,7 @@ func SCPErrorString(retcode int) string {
 
 // Close closes ssh tunnel
 func (stun *SSHTunnel) Close() fail.Error {
-	defer debug.NewTracer(nil, true).Entering().Exiting()
+	defer debug.NewTracer(ctx, true).Entering().Exiting()
 
 	defer func() {
 		if lazyErr := utils.LazyRemove(stun.keyFile.Name()); lazyErr != nil {

--- a/lib/system/ssh.go
+++ b/lib/system/ssh.go
@@ -162,7 +162,7 @@ func SCPErrorString(retcode int) string {
 
 // Close closes ssh tunnel
 func (stun *SSHTunnel) Close() fail.Error {
-	defer debug.NewTracer(ctx, true).Entering().Exiting()
+	defer debug.NewTracer(context.Background(), true).Entering().Exiting()
 
 	defer func() {
 		if lazyErr := utils.LazyRemove(stun.keyFile.Name()); lazyErr != nil {


### PR DESCRIPTION
In order to use context cancellation as intended, all functions need to pass around a context.Context as the 1st parmeter.

This does just that, pass the context in lib/server/resources