### PR TITLE
Fixes leaks in temporary files and file descriptors

### DIFF
--- a/lib/client/bucket.go
+++ b/lib/client/bucket.go
@@ -93,7 +93,15 @@ func (c bucket) Download(name string, timeout time.Duration) (*protocol.BucketDo
 		return nil, xerr
 	}
 
-	dr, err := service.Download(ctx, &protocol.BucketRequest{Name: name})
+	// finally, using context
+	newCtx := ctx
+	if timeout != 0 {
+		aCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		newCtx = aCtx
+	}
+
+	dr, err := service.Download(newCtx, &protocol.BucketRequest{Name: name})
 	return dr, err
 }
 

--- a/lib/client/remotefile.go
+++ b/lib/client/remotefile.go
@@ -75,43 +75,6 @@ func (rfc RemoteFileItem) Upload(clientSession *Session, hostname string) error 
 	return nil
 }
 
-// UploadString transfers a string as file to the remote host
-func (rfc RemoteFileItem) UploadString(clientSession *Session, content string, hostname string) error {
-	if rfc.Remote == "" {
-		return fail.InvalidInstanceContentError("rfc.Remote", "cannot be empty string")
-
-	}
-
-	// Copy the file
-	retcode, _, _, err := clientSession.SSH.Copy(rfc.Local, hostname+":"+rfc.Remote, temporal.ConnectionTimeout(), temporal.ExecutionTimeout())
-	if err != nil {
-		return err
-	}
-	if retcode != 0 {
-		return fail.NewError("failed to copy file '%s'", rfc.Local)
-	}
-
-	// Updates owner and access rights if asked for
-	cmd := ""
-	if rfc.RemoteOwner != "" {
-		cmd += "chown " + rfc.RemoteOwner + " " + rfc.Remote
-	}
-	if rfc.RemoteRights != "" {
-		if cmd != "" {
-			cmd += " && "
-		}
-		cmd += "chmod " + rfc.RemoteRights + " " + rfc.Remote
-	}
-	retcode, _, _, err = clientSession.SSH.Run(hostname, cmd, outputs.COLLECT, temporal.ConnectionTimeout(), temporal.ExecutionTimeout())
-	if err != nil {
-		return err
-	}
-	if retcode != 0 {
-		return fail.NewError("failed to update owner and/or access rights of the remote file")
-	}
-	return nil
-}
-
 // RemoveRemote deletes the remote file from host
 func (rfc RemoteFileItem) RemoveRemote(clientSession *Session, hostname string) error {
 	if clientSession == nil {

--- a/lib/server/handlers/tenant.go
+++ b/lib/server/handlers/tenant.go
@@ -872,7 +872,7 @@ func (handler *tenantHandler) collect(ctx context.Context) (ferr fail.Error) {
 		}
 		if !file.IsDir() {
 			if err = os.Remove(theFile); err != nil {
-				logrus.Infof("Error Suppressing %s : %s", file.Name(), err.Error())
+				logrus.Debugf("Error Suppressing %s : %s", file.Name(), err.Error())
 			}
 		}
 	}

--- a/lib/server/resources/metadata.go
+++ b/lib/server/resources/metadata.go
@@ -30,8 +30,6 @@ import (
 // Callback describes the function prototype to use to inspect metadata
 type Callback = func(data.Clonable, *serialize.JSONProperties) fail.Error
 
-//go:generate gowrap gen -g -p github.com/CS-SI/SafeScale/v22/lib/server/resources -i Metadata -t ./microfallback.tmpl -o mfall.go -l ""
-
 // Metadata contains the core functions of a persistent object
 type Metadata interface {
 	IsNull() bool
@@ -48,23 +46,5 @@ type Metadata interface {
 }
 
 type Consistent interface {
-	Exists(context.Context) (bool, fail.Error)
+	Exists(context.Context) (bool, fail.Error) // Exists checks if the resource actually exists in provider side (not in stow metadata)
 }
-
-/*
-//go:generate gowrap gen -g -p github.com/CS-SI/SafeScale/v22/lib/server/resources -i RawMetadata -t ./microfallback.tmpl -o breakeven.go -l ""
-
-type RawMetadata interface {
-	IsNull() bool
-	Alter(callback Callback, options ...data.ImmutableKeyValue) error // protects the data for exclusive write
-	BrowseFolder(callback func(buf []byte) error) error          // walks through host folder and executes a callback for each entry
-	Deserialize(buf []byte) error                                     // Transforms a slice of bytes in struct
-	Inspect(callback Callback) error                                  // protects the data for shared read with first reloading data from Object Storage
-	Review(callback Callback) error                                   // protects the data for shared read without reloading first (uses in-memory data); use with caution
-	Read(ref string) error                                            // reads the data from Object Storage using ref as id or name
-	ReadByID(id string) error                                         // reads the data from Object Storage by id
-	Reload() error                                 // Reloads the metadata from the Object Storage, overriding what is in the object
-	Sdump() (string, error)
-	Service() iaas.Service // returns the iaas.Service used
-}
-*/

--- a/lib/server/resources/operations/bucket.go
+++ b/lib/server/resources/operations/bucket.go
@@ -126,6 +126,7 @@ func (instance *bucket) IsNull() bool {
 	return instance == nil || instance.MetadataCore == nil || valid.IsNil(instance.MetadataCore)
 }
 
+// Exists checks if the resource actually exists in provider side (not in stow metadata)
 func (instance *bucket) Exists(ctx context.Context) (bool, fail.Error) {
 	theID := instance.GetID()
 	_, err := instance.Service().InspectBucket(theID)

--- a/lib/server/resources/operations/cluster.go
+++ b/lib/server/resources/operations/cluster.go
@@ -114,6 +114,7 @@ func NewCluster(ctx context.Context, svc iaas.Service) (_ *Cluster, ferr fail.Er
 	return instance, nil
 }
 
+// Exists checks if the resource actually exists in provider side (not in stow metadata)
 func (instance *Cluster) Exists(ctx context.Context) (bool, fail.Error) {
 	// FIXME: Requires iteration of quite a few members...
 	return true, nil

--- a/lib/server/resources/operations/clusterinstall.go
+++ b/lib/server/resources/operations/clusterinstall.go
@@ -532,7 +532,6 @@ func (instance *Cluster) ExecuteScript(ctx context.Context, tmplName string, var
 	// Uploads the script into remote file
 	rfcItem := Item{Remote: path}
 	xerr = rfcItem.UploadString(task.Context(), script, host)
-	_ = os.Remove(rfcItem.Local)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return invalid, "", "", fail.Wrap(xerr, "failed to upload %s to %s", tmplName, host.GetName())

--- a/lib/server/resources/operations/host.go
+++ b/lib/server/resources/operations/host.go
@@ -164,6 +164,7 @@ func onHostCacheMiss(ctx context.Context, svc iaas.Service, ref string) (data.Id
 	return hostInstance, nil
 }
 
+// Exists checks if the resource actually exists in provider side (not in stow metadata)
 func (instance *Host) Exists(ctx context.Context) (bool, fail.Error) {
 	theID := instance.GetID()
 	_, err := instance.Service().InspectHost(ctx, theID)
@@ -2307,7 +2308,7 @@ func (instance *Host) RelaxedDeleteHost(ctx context.Context) (ferr fail.Error) {
 
 	var shares map[string]*propertiesv1.HostShare
 	xerr = instance.Inspect(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
-		// Do not remove a Host having shares that are currently remotely mounted
+		// Do not remove a Host having shared folders that are currently remotely mounted
 		innerXErr := props.Inspect(hostproperty.SharesV1, func(clonable data.Clonable) fail.Error {
 			sharesV1, ok := clonable.(*propertiesv1.HostShares)
 			if !ok {
@@ -3756,7 +3757,7 @@ func (instance *Host) UnbindSecurityGroup(ctx context.Context, sgInstance resour
 		return xerr
 	}
 
-	// -- Remove Host reference in Security Group
+	// -- Remove Host referenced in Security Group
 	return sgInstance.Alter(ctx, func(_ data.Clonable, props *serialize.JSONProperties) fail.Error {
 		return props.Alter(securitygroupproperty.HostsV1, func(clonable data.Clonable) fail.Error {
 			sghV1, ok := clonable.(*propertiesv1.SecurityGroupHosts)

--- a/lib/server/resources/operations/host_async.go
+++ b/lib/server/resources/operations/host_async.go
@@ -4,28 +4,23 @@
 package operations
 
 import (
-	"fmt"
-	"time"
+	"os"
 
-	"github.com/CS-SI/SafeScale/v22/lib/utils/temporal"
 	"github.com/sirupsen/logrus"
 )
 
-func getCommand(file string) string {
-	// "sudo -b bash -c 'nohup %s > /dev/null 2>&1 &'"
-	command := fmt.Sprintf("sudo -b bash -c 'nohup %s > /dev/null 2>&1 &'", file)
-	logrus.Debugf("running '%s'", command)
-	return command
-}
+func getDefaultConnectorType() (string, error) {
+	if choice := os.Getenv("SAFESCALE_DEFAULT_SSH"); choice != "" {
+		switch choice {
+		case "cli":
+			return "cli", nil
+		case "lib":
+			return "lib", nil
+		default:
+			logrus.Debugf("unexpected SAFESCALE_DEFAULT_SSH: %s, using lib instead", choice)
+			return "lib", nil
+		}
+	}
 
-func getPhase2Timeout(timings temporal.Timings) time.Duration {
-	return timings.ContextTimeout()
-}
-
-func getPhase4Timeout(timings temporal.Timings) time.Duration {
-	return 30 * time.Second
-}
-
-func inBackground() bool {
-	return true
+	return "lib", nil
 }

--- a/lib/server/resources/operations/host_sync.go
+++ b/lib/server/resources/operations/host_sync.go
@@ -4,28 +4,23 @@
 package operations
 
 import (
-	"fmt"
-	"time"
+	"os"
 
-	"github.com/CS-SI/SafeScale/v22/lib/utils/temporal"
 	"github.com/sirupsen/logrus"
 )
 
-func getCommand(file string) string {
-	command := fmt.Sprintf("sudo bash %s; exit $?", file)
-	logrus.Debugf("running '%s'", command)
-	return command
-}
+func getDefaultConnectorType() (string, error) {
+	if choice := os.Getenv("SAFESCALE_DEFAULT_SSH"); choice != "" {
+		switch choice {
+		case "cli":
+			return "cli", nil
+		case "lib":
+			return "lib", nil
+		default:
+			logrus.Debugf("unexpected SAFESCALE_DEFAULT_SSH: %s, using cli instead", choice)
+			return "cli", nil
+		}
+	}
 
-func getPhase2Timeout(timings temporal.Timings) time.Duration {
-	return timings.HostOperationTimeout()
-}
-
-func getPhase4Timeout(timings temporal.Timings) time.Duration {
-	waitingTime := temporal.MaxTimeout(4*time.Minute, timings.HostCreationTimeout())
-	return waitingTime
-}
-
-func inBackground() bool {
-	return false
+	return "cli", nil
 }

--- a/lib/server/resources/operations/installstep.go
+++ b/lib/server/resources/operations/installstep.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -540,9 +539,6 @@ func (is *step) taskRunOnHost(task concurrency.Task, params concurrency.TaskPara
 		Remote: filename,
 	}
 
-	defer func() {
-		_ = os.Remove(rfcItem.Local)
-	}()
 	xerr = rfcItem.UploadString(task.Context(), command, p.Host)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {

--- a/lib/server/resources/operations/network.go
+++ b/lib/server/resources/operations/network.go
@@ -124,6 +124,7 @@ func (instance *Network) IsNull() bool {
 	return instance == nil || instance.MetadataCore == nil || valid.IsNil(instance.MetadataCore)
 }
 
+// Exists checks if the resource actually exists in provider side (not in stow metadata)
 func (instance *Network) Exists(ctx context.Context) (bool, fail.Error) {
 	theID := instance.GetID()
 	_, err := instance.Service().InspectNetwork(ctx, theID)

--- a/lib/server/resources/operations/securitygroup.go
+++ b/lib/server/resources/operations/securitygroup.go
@@ -138,6 +138,7 @@ func (instance *SecurityGroup) IsNull() bool {
 	return valid.IsNil(instance.MetadataCore)
 }
 
+// Exists checks if the resource actually exists in provider side (not in stow metadata)
 func (instance *SecurityGroup) Exists(ctx context.Context) (bool, fail.Error) {
 	// FIXME: Not so easy, securitygroups are in some cases a metadata-only construct -> we need to turn those into tags (provider ones) 1st
 	return true, nil

--- a/lib/server/resources/operations/share.go
+++ b/lib/server/resources/operations/share.go
@@ -196,6 +196,7 @@ func (instance *Share) IsNull() bool {
 	return instance == nil || instance.MetadataCore == nil || valid.IsNil(instance.MetadataCore)
 }
 
+// Exists checks if the resource actually exists in provider side (not in stow metadata)
 func (instance *Share) Exists(ctx context.Context) (bool, fail.Error) {
 	// FIXME: There is no InspectShare
 	return true, nil

--- a/lib/server/resources/operations/subnet.go
+++ b/lib/server/resources/operations/subnet.go
@@ -352,10 +352,12 @@ func (instance *Subnet) updateCachedInformation(ctx context.Context) fail.Error 
 	return nil
 }
 
+// IsNull tells if the instance is a null value
 func (instance *Subnet) IsNull() bool {
 	return instance == nil || (instance != nil && ((instance.MetadataCore == nil) || (instance.MetadataCore != nil && valid.IsNil(instance.MetadataCore))))
 }
 
+// Exists checks if the resource actually exists in provider side (not in stow metadata)
 func (instance *Subnet) Exists(ctx context.Context) (bool, fail.Error) {
 	theID := instance.GetID()
 	_, err := instance.Service().InspectSubnet(ctx, theID)

--- a/lib/server/resources/operations/subnettasks.go
+++ b/lib/server/resources/operations/subnettasks.go
@@ -227,7 +227,7 @@ func (instance *Subnet) taskFinalizeGatewayConfiguration(task concurrency.Task, 
 		fmt.Sprintf("Ending final configuration phases on the gateway '%s'", gwname),
 	)()
 
-	waitingTime := 4 * time.Minute // FIXME: Hardcoded timeout
+	waitingTime := temporal.MaxTimeout(4*time.Minute, timings.HostCreationTimeout())
 
 	if objgw.thePhaseDoesSomething(task.Context(), userdata.PHASE3_GATEWAY_HIGH_AVAILABILITY, userData) {
 		xerr = objgw.runInstallPhase(task.Context(), userdata.PHASE3_GATEWAY_HIGH_AVAILABILITY, userData, waitingTime)
@@ -262,7 +262,7 @@ func (instance *Subnet) taskFinalizeGatewayConfiguration(task concurrency.Task, 
 
 		time.Sleep(timings.RebootTimeout())
 
-		_, xerr = objgw.waitInstallPhase(task.Context(), userdata.PHASE4_SYSTEM_FIXES, 0)
+		_, xerr = objgw.waitInstallPhase(task.Context(), userdata.PHASE4_SYSTEM_FIXES, waitingTime)
 		xerr = debug.InjectPlannedFail(xerr)
 		if xerr != nil {
 			return nil, xerr
@@ -279,7 +279,7 @@ func (instance *Subnet) taskFinalizeGatewayConfiguration(task concurrency.Task, 
 	}
 
 	// By design, phase 5 doesn't  touch network cfg, so no reboot needed
-	_, xerr = objgw.waitInstallPhase(task.Context(), userdata.PHASE5_FINAL, time.Duration(0))
+	_, xerr = objgw.waitInstallPhase(task.Context(), userdata.PHASE5_FINAL, waitingTime)
 	xerr = debug.InjectPlannedFail(xerr)
 	if xerr != nil {
 		return nil, xerr

--- a/lib/server/resources/operations/volume.go
+++ b/lib/server/resources/operations/volume.go
@@ -133,6 +133,7 @@ func (instance *volume) IsNull() bool {
 	return instance == nil || instance.MetadataCore == nil || valid.IsNil(instance.MetadataCore)
 }
 
+// Exists checks if the resource actually exists in provider side (not in stow metadata)
 func (instance *volume) Exists(ctx context.Context) (bool, fail.Error) {
 	theID := instance.GetID()
 	_, err := instance.Service().InspectVolume(ctx, theID)

--- a/lib/system/bucketfs/description.go
+++ b/lib/system/bucketfs/description.go
@@ -25,6 +25,7 @@ import (
 	"github.com/CS-SI/SafeScale/v22/lib/system/ssh"
 	"github.com/CS-SI/SafeScale/v22/lib/utils"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/fail"
+	"github.com/sirupsen/logrus"
 )
 
 // Description contains the configuration for bucket mount
@@ -51,7 +52,10 @@ func (desc *Description) upload(ctx context.Context, host resources.Host) fail.E
 
 	// cleanup local temporary file
 	defer func() {
-		_ = os.Remove(f.Name())
+		rerr := utils.LazyRemove(f.Name())
+		if rerr != nil {
+			logrus.Debugf(rerr.Error())
+		}
 	}()
 
 	svc := host.Service()

--- a/lib/system/ssh/sshtunnel/ssh_tunnel.go
+++ b/lib/system/ssh/sshtunnel/ssh_tunnel.go
@@ -216,7 +216,7 @@ func (tunnel *SSHTunnel) Start() (err error) {
 
 	tunnel.mu.Lock()
 	if tunnel.isOpen {
-		tunnel.mu.Unlock()
+		tunnel.mu.Unlock() // nolint
 		return fmt.Errorf("error starting the ssh tunnel: already started")
 	}
 
@@ -253,10 +253,10 @@ func (tunnel *SSHTunnel) Start() (err error) {
 	for {
 		tunnel.mu.Lock()
 		if !tunnel.isOpen {
-			tunnel.mu.Unlock()
+			tunnel.mu.Unlock() // nolint
 			break
 		}
-		tunnel.mu.Unlock()
+		tunnel.mu.Unlock() // nolint
 
 		errCh := make(chan error)
 		connCh := make(chan net.Conn)

--- a/lib/system/ssh/sshtunnel/ssh_tunnel.go
+++ b/lib/system/ssh/sshtunnel/ssh_tunnel.go
@@ -641,6 +641,7 @@ func (tunnel *SSHTunnel) forward(localConn net.Conn) (err error) {
 }
 
 func (tunnel *SSHTunnel) Close() { // kept for compatibility issues
+	tunnel.quit()
 	return // nolint
 }
 

--- a/lib/system/ssh/sshtunnel/ssh_tunnel.go
+++ b/lib/system/ssh/sshtunnel/ssh_tunnel.go
@@ -36,6 +36,8 @@ type logger interface {
 	Printf(string, ...interface{})
 }
 
+type Printfer = logger
+
 type extendedLogger interface {
 	Printf(string, ...interface{})
 	Errorf(string, ...interface{})
@@ -70,7 +72,7 @@ type Option func(tunnel *SSHTunnel) error
 
 type SSHTunnel struct {
 	local  *Entrypoint
-	server *SSHJump // a.k.a the gateway, or the jump
+	server *SSHJump // a.k.a. the gateway, or the jump
 	remote *Endpoint
 
 	config *ssh.ClientConfig
@@ -140,6 +142,10 @@ func (tunnel SSHTunnel) GetServerEndpoint() Endpoint {
 
 func (tunnel *SSHTunnel) SetCommand(cmd string) {
 	tunnel.command = cmd
+}
+
+func (tunnel *SSHTunnel) GetLogger() Printfer {
+	return tunnel.log
 }
 
 func (tunnel *SSHTunnel) newConnectionWaiter(listener net.Listener, c chan net.Conn) (err error) {
@@ -380,6 +386,13 @@ func TunnelOptionWithDefaultKeepAlive() Option {
 func TunnelOptionWithLogger(myLogger logger) Option {
 	return func(tunnel *SSHTunnel) error {
 		tunnel.log = myLogger
+		return nil
+	}
+}
+
+func TunnelOptionWithTrustedKey(tk string) Option {
+	return func(tunnel *SSHTunnel) error {
+		tunnel.config.HostKeyCallback = TrustedHostKeyCallbackWithLogger(tunnel.log, tk)
 		return nil
 	}
 }

--- a/lib/utils/net/tcp.go
+++ b/lib/utils/net/tcp.go
@@ -19,13 +19,14 @@ package net
 import (
 	"net"
 	"strconv"
-	"time"
+
+	"github.com/CS-SI/SafeScale/v22/lib/utils/temporal"
 )
 
 // CheckRemoteTCP returns true if ip:port is listening, false otherwise
 func CheckRemoteTCP(ip string, port int) bool {
 	address := net.JoinHostPort(ip, strconv.Itoa(port))
-	conn, err := net.DialTimeout("tcp", address, 3*time.Second) // FIXME: change timeout to temporal.XXX function
+	conn, err := net.DialTimeout("tcp", address, 30*temporal.SmallDelay())
 	if err != nil {
 		return false
 	}

--- a/lib/utils/temporal/timings.go
+++ b/lib/utils/temporal/timings.go
@@ -49,7 +49,7 @@ const (
 	defaultOperationTimeout = 150 * time.Second
 
 	// defaultWaitAfterReboot time we wait after a reboot before trying SSH connection
-	defaultWaitAfterReboot = 45 * time.Second
+	defaultWaitAfterReboot = 100 * time.Second
 
 	// defaultSSHConnectionTimeout is the default ssh timeout connection
 	defaultSSHConnectionTimeout = 2 * time.Minute


### PR DESCRIPTION
Both cli and lib versions of ssh had problems leaking resources, this PR address this problems, also cleans logs and removes unused functions.