### PR TITLE
Removed omitempty from some enumerations

### DIFF
--- a/lib/server/resources/abstract/host.go
+++ b/lib/server/resources/abstract/host.go
@@ -236,8 +236,8 @@ type HostCore struct {
 	PrivateKey        string            `json:"private_key,omitempty"`
 	SSHPort           uint32            `json:"ssh_port,omitempty"`
 	Password          string            `json:"password,omitempty"`
-	LastState         hoststate.Enum    `json:"last_state,omitempty"`
-	ProvisioningState hoststate.Enum    `json:"provisioning_state,omitempty"`
+	LastState         hoststate.Enum    `json:"last_state"`
+	ProvisioningState hoststate.Enum    `json:"provisioning_state"`
 	Tags              map[string]string `json:"tags,omitempty"`
 }
 
@@ -399,7 +399,7 @@ type HostFull struct {
 	Sizing       *HostEffectiveSizing
 	Networking   *HostNetworking
 	Description  *HostDescription
-	CurrentState hoststate.Enum `json:"current_state,omitempty"`
+	CurrentState hoststate.Enum `json:"current_state"`
 }
 
 // NewHostFull creates an instance of HostFull

--- a/lib/server/resources/abstract/volume.go
+++ b/lib/server/resources/abstract/volume.go
@@ -31,7 +31,7 @@ import (
 type VolumeRequest struct {
 	Name  string           `json:"name,omitempty"`
 	Size  int              `json:"size,omitempty"`
-	Speed volumespeed.Enum `json:"speed,omitempty"`
+	Speed volumespeed.Enum `json:"speed"`
 }
 
 // Volume represents a block volume
@@ -39,8 +39,8 @@ type Volume struct {
 	ID    string            `json:"id,omitempty"`
 	Name  string            `json:"name,omitempty"`
 	Size  int               `json:"size,omitempty"`
-	Speed volumespeed.Enum  `json:"speed,omitempty"`
-	State volumestate.Enum  `json:"state,omitempty"`
+	Speed volumespeed.Enum  `json:"speed"`
+	State volumestate.Enum  `json:"state"`
 	Tags  map[string]string `json:"tags,omitempty"`
 }
 


### PR DESCRIPTION
State has to be stored in metadata even if its state is initally unknown, so the json tag omitempty must be removed from some structs.