### PR TITLE
Fixed file not in git, preventing use of SafeScale as imported package

### DIFF
--- a/lib/utils/valid/consts.go
+++ b/lib/utils/valid/consts.go
@@ -1,0 +1,3 @@
+package valid
+
+const EmbeddedErrorStructName = "errorCore"


### PR DESCRIPTION
- lib/utils/valid needs a file const.go to exist with default value
