### PR TITLE
Use tags defined by providers

### DIFF
--- a/lib/backend/iaas/providers/providerproxy.go
+++ b/lib/backend/iaas/providers/providerproxy.go
@@ -719,13 +719,3 @@ func (s ProviderProxy) DeleteVolumeAttachment(ctx context.Context, serverID, id 
 	}
 	return xerr
 }
-
-func (s ProviderProxy) Migrate(ctx context.Context, operation string, params map[string]interface{}) (ferr fail.Error) {
-	defer fail.OnPanic(&ferr)
-
-	xerr := s.Provider.Migrate(ctx, operation, params)
-	if xerr != nil {
-		xerr.WithContext(ctx)
-	}
-	return xerr
-}

--- a/lib/backend/iaas/stacks/api/stack.go
+++ b/lib/backend/iaas/stacks/api/stack.go
@@ -161,11 +161,13 @@ type Stack interface {
 	// DeleteVolumeAttachment deletes the volume attachment identified by id
 	DeleteVolumeAttachment(ctx context.Context, serverID, id string) fail.Error
 
-	// Migrate runs custom code without breaking Interfaces
-	Migrate(ctx context.Context, operation string, params map[string]interface{}) fail.Error
-
 	// Timings ...
 	Timings() (temporal.Timings, fail.Error)
+
+	// FIXME: OPP not anymore
+
+	UpdateTags(ctx context.Context, kind abstract.Enum, id string, lmap map[string]string) fail.Error
+	DeleteTags(ctx context.Context, kind abstract.Enum, id string, keys []string) fail.Error
 }
 
 // ReservedForProviderUse is an interface about the methods only available to providers internally

--- a/lib/backend/iaas/stacks/api/stackproxy.go
+++ b/lib/backend/iaas/stacks/api/stackproxy.go
@@ -647,13 +647,3 @@ func (s StackProxy) DeleteVolumeAttachment(ctx context.Context, serverID, id str
 	}
 	return xerr
 }
-
-func (s StackProxy) Migrate(ctx context.Context, operation string, params map[string]interface{}) (ferr fail.Error) {
-	defer fail.OnPanic(&ferr)
-
-	xerr := s.FullStack.Migrate(ctx, operation, params)
-	if xerr != nil {
-		xerr.WithContext(ctx)
-	}
-	return xerr
-}

--- a/lib/backend/iaas/stacks/aws/compute.go
+++ b/lib/backend/iaas/stacks/aws/compute.go
@@ -797,7 +797,7 @@ func (s stack) buildAwsMachine(
 	template abstract.HostTemplate,
 ) (*abstract.HostCore, fail.Error) {
 
-	instance, xerr := s.rpcRunInstance(ctx,
+	instance, xerr := s.rpcCreateInstance(ctx,
 		aws.String(name), aws.String(zone), aws.String(subnetID), aws.String(template.ID), aws.String(imageID), diskSize,
 		aws.String(keypairName), aws.Bool(publicIP), []byte(data),
 	)

--- a/lib/backend/iaas/stacks/gcp/stack.go
+++ b/lib/backend/iaas/stacks/gcp/stack.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/CS-SI/SafeScale/v22/lib/backend/resources/abstract"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/valid"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
@@ -120,4 +121,36 @@ func (s *stack) Timings() (temporal.Timings, fail.Error) {
 		s.MutableTimings = temporal.NewTimings()
 	}
 	return s.MutableTimings, nil
+}
+
+func (s *stack) UpdateTags(ctx context.Context, kind abstract.Enum, id string, lmap map[string]string) fail.Error {
+	if kind != abstract.HostResource {
+		return fail.NotImplementedError("Tagging resources other than hosts not implemented yet")
+	}
+
+	xerr := s.rpcCreateTags(ctx, id, lmap)
+	if xerr != nil {
+		return xerr
+	}
+
+	xerr = s.rpcCreateLabels(ctx, id, lmap)
+	return xerr
+}
+
+func (s *stack) DeleteTags(ctx context.Context, kind abstract.Enum, id string, keys []string) fail.Error {
+	if kind != abstract.HostResource {
+		return fail.NotImplementedError("Tagging resources other than hosts not implemented yet")
+	}
+
+	xerr := s.rpcRemoveTagsFromInstance(ctx, id, keys)
+	if xerr != nil {
+		return xerr
+	}
+
+	xerr = s.rpcRemoveLabels(ctx, id, keys)
+	if xerr != nil {
+		return xerr
+	}
+
+	return nil
 }

--- a/lib/backend/iaas/stacks/huaweicloud/compute.go
+++ b/lib/backend/iaas/stacks/huaweicloud/compute.go
@@ -779,8 +779,7 @@ func validateHostname(req abstract.HostRequest) (bool, fail.Error) {
 	return true, nil
 }
 
-// FIXME: Remove this function later when searchInStruct is ready
-func extractImageTheLongWay(in *images.Image) (_ abstract.Image, ferr fail.Error) { // nolint
+func extractImage(in *images.Image) (_ abstract.Image, ferr fail.Error) {
 	defer fail.OnPanic(&ferr)
 
 	properties := in.Properties
@@ -821,28 +820,6 @@ func extractImageTheLongWay(in *images.Image) (_ abstract.Image, ferr fail.Error
 	if !ok {
 		return abstract.Image{}, fail.NewError("invalid new format")
 	}
-
-	out := abstract.Image{
-		ID:       id,
-		Name:     name,
-		DiskSize: int64(d),
-	}
-
-	return out, nil
-}
-
-func extractImage(in *images.Image) (_ abstract.Image, ferr fail.Error) {
-	defer fail.OnPanic(&ferr)
-
-	// following code will eventually break or panic
-	// FIXME: Write function that can search external structs without panicking, like jq for json
-	// so we can write something like searchInStruct(in.Properties, ".Properties.image.minDisk")
-
-	properties := in.Properties
-	image := properties["image"].(map[string]interface{}) // nolint
-	d := image["minDisk"].(float64)                       // nolint
-	id := image["id"].(string)                            // nolint
-	name := image["name"].(string)                        // nolint
 
 	out := abstract.Image{
 		ID:       id,
@@ -1517,32 +1494,6 @@ func (s stack) enableHostRouterMode(ctx context.Context, host *abstract.HostFull
 				},
 			}
 			opts := ports.UpdateOpts{AllowedAddressPairs: &pairs}
-			_, innerErr := ports.Update(s.NetworkClient, *portID, opts).Extract()
-			return normalizeError(innerErr)
-		},
-		normalizeError,
-	)
-	if commRetryErr != nil {
-		return commRetryErr
-	}
-	return nil
-}
-
-// DisableHostRouterMode disables the host to act as a router/gateway.
-func (s stack) disableHostRouterMode(ctx context.Context, host *abstract.HostFull) fail.Error {
-	portID, xerr := s.getOpenstackPortID(ctx, host)
-	if xerr != nil {
-		return fail.NewErrorWithCause(xerr, "failed to disable Router Mode on host '%s'", host.Core.Name)
-	}
-	if portID == nil {
-		return fail.NewError(
-			"failed to disable Router Mode on host '%s': failed to find OpenStack port", host.Core.Name,
-		)
-	}
-
-	commRetryErr := stacks.RetryableRemoteCall(ctx,
-		func() error {
-			opts := ports.UpdateOpts{AllowedAddressPairs: nil}
 			_, innerErr := ports.Update(s.NetworkClient, *portID, opts).Extract()
 			return normalizeError(innerErr)
 		},

--- a/lib/backend/iaas/stacks/huaweicloud/network.go
+++ b/lib/backend/iaas/stacks/huaweicloud/network.go
@@ -92,9 +92,6 @@ type vpcCreateResult struct {
 type vpcGetResult struct {
 	vpcCommonResult
 }
-type vpcDeleteResult struct { // nolint
-	gophercloud.ErrResult
-}
 
 // HasDefaultNetwork returns true if the stack as a default network set (coming from tenants file)
 func (s stack) HasDefaultNetwork(context.Context) (bool, fail.Error) {
@@ -745,9 +742,6 @@ type subnetCreateResult struct {
 }
 type subnetGetResult struct {
 	subnetCommonResult
-}
-type subnetDeleteResult struct { // nolint
-	gophercloud.ErrResult
 }
 
 // createSubnet creates a subnet using native FlexibleEngine API

--- a/lib/backend/iaas/stacks/huaweicloud/rpc.go
+++ b/lib/backend/iaas/stacks/huaweicloud/rpc.go
@@ -21,17 +21,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
-	"time"
-
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
-	"github.com/gophercloud/gophercloud/pagination"
 
 	"github.com/CS-SI/SafeScale/v22/lib/backend/iaas/stacks"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/fail"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/retry"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"github.com/gophercloud/gophercloud/pagination"
 )
 
 func (s stack) rpcGetHostByID(ctx context.Context, id string) (*servers.Server, fail.Error) {
@@ -51,14 +48,6 @@ func (s stack) rpcGetHostByID(ctx context.Context, id string) (*servers.Server, 
 		return nil, xerr
 	}
 	return server, nil
-}
-
-func closer(hr *http.Response) {
-	if hr != nil {
-		if hr.Body != nil {
-			_ = hr.Body.Close()
-		}
-	}
 }
 
 func (s stack) rpcGetHostByName(ctx context.Context, name string) (*servers.Server, fail.Error) {
@@ -122,149 +111,6 @@ func (s stack) rpcGetHostByName(ctx context.Context, name string) (*servers.Serv
 	return nil, fail.InconsistentError("found more than one Host named '%s'", name)
 }
 
-// rpcGetMetadataOfInstance returns the metadata associated with the instance
-func (s stack) rpcGetMetadataOfInstance(ctx context.Context, id string) (map[string]string, fail.Error) {
-	emptyMap := map[string]string{}
-	if id = strings.TrimSpace(id); id == "" {
-		return emptyMap, fail.InvalidParameterError("id", "cannpt be empty string")
-	}
-
-	var out map[string]string
-	xerr := stacks.RetryableRemoteCall(ctx,
-		func() (innerErr error) {
-			res := servers.Metadata(s.ComputeClient, id)
-			out, innerErr = res.Extract()
-			return innerErr
-		},
-		NormalizeError,
-	)
-	if xerr != nil {
-		switch xerr.(type) {
-		case *fail.ErrTimeout:
-			return emptyMap, fail.Wrap(fail.Cause(xerr), "timeout")
-		case *retry.ErrStopRetry:
-			return emptyMap, fail.Wrap(fail.Cause(xerr), "stopping retries")
-		default:
-			return emptyMap, xerr
-		}
-	}
-
-	return out, nil
-}
-
-// rpcListServers lists servers
-func (s stack) rpcListServers(ctx context.Context) ([]*servers.Server, fail.Error) {
-	var resp []*servers.Server
-	xerr := stacks.RetryableRemoteCall(ctx,
-		func() (innerErr error) {
-			allPages, innerErr := servers.List(s.ComputeClient, nil).AllPages()
-			if innerErr != nil {
-				return innerErr
-			}
-			if innerErr := servers.ExtractServersInto(allPages, &resp); innerErr != nil {
-				return innerErr
-			}
-			return nil
-		},
-		NormalizeError,
-	)
-	if xerr != nil {
-		return []*servers.Server{}, xerr
-	}
-
-	return resp, nil
-}
-
-// rpcCreateServer calls openstack to create a server
-func (s stack) rpcCreateServer(ctx context.Context, name string, networks []servers.Network, templateID, imageID string, userdata []byte, az string) (*servers.Server, fail.Error) {
-	if name = strings.TrimSpace(name); name == "" {
-		return nil, fail.InvalidParameterCannotBeEmptyStringError("name")
-	}
-	if templateID = strings.TrimSpace(templateID); templateID == "" {
-		return nil, fail.InvalidParameterCannotBeEmptyStringError("templateID")
-	}
-	if imageID = strings.TrimSpace(imageID); imageID == "" {
-		return nil, fail.InvalidParameterCannotBeEmptyStringError("imageID")
-	}
-	if az == "" {
-		return nil, fail.InvalidParameterCannotBeEmptyStringError("az")
-	}
-
-	metadata := make(map[string]string)
-	metadata["ManagedBy"] = "safescale"
-	metadata["DeclaredInBucket"] = s.cfgOpts.MetadataBucket
-	metadata["Image"] = imageID
-	metadata["Template"] = templateID
-	metadata["CreationDate"] = time.Now().Format(time.RFC3339)
-
-	srvOpts := servers.CreateOpts{
-		Name:             name,
-		Networks:         networks,
-		FlavorRef:        templateID,
-		ImageRef:         imageID,
-		UserData:         userdata,
-		AvailabilityZone: az,
-		Metadata:         metadata,
-	}
-
-	var server *servers.Server
-	xerr := stacks.RetryableRemoteCall(ctx,
-		func() (innerErr error) {
-			server, innerErr = servers.Create(s.ComputeClient, srvOpts).Extract()
-			return innerErr
-		},
-		NormalizeError,
-	)
-	if xerr != nil {
-		return &servers.Server{}, xerr
-	}
-	return server, nil
-}
-
-// rpcDeleteServer calls openstack to delete a server
-func (s stack) rpcDeleteServer(ctx context.Context, id string) fail.Error {
-	if id == "" {
-		return fail.InvalidParameterCannotBeEmptyStringError("id")
-	}
-
-	return stacks.RetryableRemoteCall(ctx,
-		func() error {
-			return servers.Delete(s.ComputeClient, id).ExtractErr()
-		},
-		NormalizeError,
-	)
-}
-
-// rpcCreatePort creates a port
-func (s stack) rpcCreatePort(ctx context.Context, req ports.CreateOpts) (port *ports.Port, ferr fail.Error) {
-	xerr := stacks.RetryableRemoteCall(ctx,
-		func() (innerErr error) {
-			port, innerErr = ports.Create(s.NetworkClient, req).Extract()
-			return innerErr
-		},
-		NormalizeError,
-	)
-	if xerr != nil {
-		return nil, xerr
-	}
-
-	return port, nil
-}
-
-// rpcDeletePort deletes a port
-func (s stack) rpcDeletePort(ctx context.Context, id string) fail.Error {
-	if id = strings.TrimSpace(id); id == "" {
-		return fail.InvalidParameterError("id", "cannot be empty string")
-	}
-
-	return stacks.RetryableRemoteCall(ctx,
-		func() (innerErr error) {
-			return ports.Delete(s.NetworkClient, id).ExtractErr()
-		},
-		NormalizeError,
-	)
-}
-
 // rpcListPorts lists all ports available
 func (s stack) rpcListPorts(ctx context.Context, options ports.ListOpts) ([]ports.Port, fail.Error) {
 	var (
@@ -289,72 +135,90 @@ func (s stack) rpcListPorts(ctx context.Context, options ports.ListOpts) ([]port
 	return r, nil
 }
 
-// rpcUpdatePort updates the settings of a port
-func (s stack) rpcUpdatePort(ctx context.Context, id string, options ports.UpdateOpts) fail.Error {
-	if id == "" {
-		return fail.InvalidParameterCannotBeEmptyStringError("id")
+// rpcSetMetadataOfInstance changes the metadata associated with the instance
+func (s stack) rpcSetMetadataOfInstance(ctx context.Context, id string, tags map[string]string) fail.Error {
+	if id = strings.TrimSpace(id); id == "" {
+		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	return stacks.RetryableRemoteCall(ctx,
-		func() error {
-			resp, innerErr := ports.Update(s.NetworkClient, id, options).Extract()
-			_ = resp
-			return innerErr
-		},
-		NormalizeError,
-	)
-}
-
-// rpcGetPort returns port information from its ID
-func (s stack) rpcGetPort(ctx context.Context, id string) (port *ports.Port, ferr fail.Error) {
-	if id == "" {
-		return nil, fail.InvalidParameterCannotBeEmptyStringError("id")
-	}
-
+	var out map[string]string
 	xerr := stacks.RetryableRemoteCall(ctx,
 		func() (innerErr error) {
-			port, innerErr = ports.Get(s.NetworkClient, id).Extract()
+			res := servers.Metadata(s.ComputeClient, id)
+			out, innerErr = res.Extract()
 			return innerErr
 		},
 		NormalizeError,
 	)
 	if xerr != nil {
-		return nil, xerr
+		switch xerr.(type) {
+		case *fail.ErrTimeout:
+			return fail.Wrap(fail.Cause(xerr), "timeout")
+		case *retry.ErrStopRetry:
+			return fail.Wrap(fail.Cause(xerr), "stopping retries")
+		default:
+			return xerr
+		}
 	}
 
-	return port, nil
-}
+	for k, v := range tags {
+		out[k] = v
+	}
 
-// rpcCreateFloatingIP creates a floating IP
-func (s stack) rpcCreateFloatingIP(ctx context.Context) (*floatingips.FloatingIP, fail.Error) {
-	var resp *floatingips.FloatingIP
-	xerr := stacks.RetryableRemoteCall(ctx,
+	mop := make(servers.MetadataOpts)
+	for k, v := range out {
+		mop[k] = v
+	}
+
+	xerr = stacks.RetryableRemoteCall(ctx,
 		func() (innerErr error) {
-			resp, innerErr = floatingips.Create(
-				s.ComputeClient, floatingips.CreateOpts{
-					Pool: s.authOpts.FloatingIPPool,
-				},
-			).Extract()
+			res := servers.UpdateMetadata(s.ComputeClient, id, mop)
+			_, innerErr = res.Extract()
 			return innerErr
 		},
 		NormalizeError,
 	)
 	if xerr != nil {
-		return &floatingips.FloatingIP{}, xerr
+		switch xerr.(type) {
+		case *fail.ErrTimeout:
+			return fail.Wrap(fail.Cause(xerr), "timeout")
+		case *retry.ErrStopRetry:
+			return fail.Wrap(fail.Cause(xerr), "stopping retries")
+		default:
+			return xerr
+		}
 	}
-	return resp, nil
+
+	return nil
 }
 
-// rpcDeleteFloatingIP deletes a floating IP
-func (s stack) rpcDeleteFloatingIP(ctx context.Context, id string) fail.Error {
-	if id == "" {
-		return fail.InvalidParameterCannotBeEmptyStringError("id")
+// rpcDeleteMetadataOfInstance changes the metadata associated with the instance
+func (s stack) rpcDeleteMetadataOfInstance(ctx context.Context, id string, tags map[string]string) fail.Error {
+	if id = strings.TrimSpace(id); id == "" {
+		return fail.InvalidParameterError("id", "cannot be empty string")
 	}
 
-	return stacks.RetryableRemoteCall(ctx,
-		func() error {
-			return floatingips.Delete(s.ComputeClient, id).ExtractErr()
+	xerr := stacks.RetryableRemoteCall(ctx,
+		func() (innerErr error) {
+			for k := range tags {
+				res := servers.DeleteMetadatum(s.ComputeClient, id, k)
+				innerErr = res.ExtractErr()
+				return innerErr
+			}
+			return nil
 		},
 		NormalizeError,
 	)
+	if xerr != nil {
+		switch xerr.(type) {
+		case *fail.ErrTimeout:
+			return fail.Wrap(fail.Cause(xerr), "timeout")
+		case *retry.ErrStopRetry:
+			return fail.Wrap(fail.Cause(xerr), "stopping retries")
+		default:
+			return xerr
+		}
+	}
+
+	return nil
 }

--- a/lib/backend/iaas/stacks/huaweicloud/stack.go
+++ b/lib/backend/iaas/stacks/huaweicloud/stack.go
@@ -1144,3 +1144,26 @@ func (s *stack) Timings() (temporal.Timings, fail.Error) {
 	}
 	return s.MutableTimings, nil
 }
+
+func (s *stack) UpdateTags(ctx context.Context, kind abstract.Enum, id string, lmap map[string]string) fail.Error {
+	if kind != abstract.HostResource {
+		return fail.NotImplementedError("Tagging resources other than hosts not implemented yet")
+	}
+
+	xerr := s.rpcSetMetadataOfInstance(ctx, id, lmap)
+	return xerr
+}
+
+func (s *stack) DeleteTags(ctx context.Context, kind abstract.Enum, id string, keys []string) fail.Error {
+	if kind != abstract.HostResource {
+		return fail.NotImplementedError("Tagging resources other than hosts not implemented yet")
+	}
+
+	report := make(map[string]string)
+	for _, k := range keys {
+		report[k] = ""
+	}
+
+	xerr := s.rpcDeleteMetadataOfInstance(ctx, id, report)
+	return xerr
+}

--- a/lib/backend/iaas/stacks/huaweicloud/support.go
+++ b/lib/backend/iaas/stacks/huaweicloud/support.go
@@ -1,0 +1,11 @@
+package huaweicloud
+
+import "net/http"
+
+func closer(hr *http.Response) {
+	if hr != nil {
+		if hr.Body != nil {
+			_ = hr.Body.Close()
+		}
+	}
+}

--- a/lib/backend/iaas/stacks/openstack/compute.go
+++ b/lib/backend/iaas/stacks/openstack/compute.go
@@ -893,6 +893,7 @@ func (s stack) CreateHost(ctx context.Context, request abstract.HostRequest) (ho
 					return innerXErr
 				}
 			}
+
 			return nil
 		},
 		timings.NormalDelay(),

--- a/lib/backend/iaas/stacks/openstack/error.go
+++ b/lib/backend/iaas/stacks/openstack/error.go
@@ -22,15 +22,12 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"reflect"
 	"strings"
 
 	"github.com/CS-SI/SafeScale/v22/lib/utils/debug"
-	"github.com/CS-SI/SafeScale/v22/lib/utils/debug/callstack"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/debug/tracing"
 	"github.com/CS-SI/SafeScale/v22/lib/utils/fail"
 	"github.com/gophercloud/gophercloud"
-	"github.com/sirupsen/logrus"
 )
 
 // NormalizeError translates gophercloud or openstack error to SafeScale error
@@ -141,14 +138,7 @@ func NormalizeError(err error) fail.Error {
 			tracer.Trace("received 'net.Error', normalized to 'fail.Error' with cause")
 			return fail.NewErrorWithCause(e)
 		default:
-			switch err.Error() {
-			case "EOF":
-				tracer.Trace("received 'EOF', normalized to '*fail.ErrNotFound'")
-				return fail.NotFoundError("EOF")
-			default:
-				logrus.WithContext(context.Background()).Debugf(callstack.DecorateWith("", "", fmt.Sprintf("Unhandled error (%s) received from provider: %s", reflect.TypeOf(err).String(), err.Error()), 0))
-				return fail.NewError("unhandled error received from provider: %s", err.Error())
-			}
+			return fail.ConvertError(defaultErrorInterpreter(err))
 		}
 	}
 	return nil

--- a/lib/backend/iaas/stacks/openstack/rpc.go
+++ b/lib/backend/iaas/stacks/openstack/rpc.go
@@ -141,6 +141,94 @@ func (s stack) rpcGetMetadataOfInstance(ctx context.Context, id string) (map[str
 	return out, nil
 }
 
+// rpcSetMetadataOfInstance changes the metadata associated with the instance
+func (s stack) rpcSetMetadataOfInstance(ctx context.Context, id string, tags map[string]string) fail.Error {
+	if id = strings.TrimSpace(id); id == "" {
+		return fail.InvalidParameterError("id", "cannot be empty string")
+	}
+
+	var out map[string]string
+	xerr := stacks.RetryableRemoteCall(ctx,
+		func() (innerErr error) {
+			res := servers.Metadata(s.ComputeClient, id)
+			out, innerErr = res.Extract()
+			return innerErr
+		},
+		NormalizeError,
+	)
+	if xerr != nil {
+		switch xerr.(type) {
+		case *fail.ErrTimeout:
+			return fail.Wrap(fail.Cause(xerr), "timeout")
+		case *retry.ErrStopRetry:
+			return fail.Wrap(fail.Cause(xerr), "stopping retries")
+		default:
+			return xerr
+		}
+	}
+
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	mop := make(servers.MetadataOpts)
+	for k, v := range out {
+		mop[k] = v
+	}
+
+	xerr = stacks.RetryableRemoteCall(ctx,
+		func() (innerErr error) {
+			res := servers.UpdateMetadata(s.ComputeClient, id, mop)
+			_, innerErr = res.Extract()
+			return innerErr
+		},
+		NormalizeError,
+	)
+	if xerr != nil {
+		switch xerr.(type) {
+		case *fail.ErrTimeout:
+			return fail.Wrap(fail.Cause(xerr), "timeout")
+		case *retry.ErrStopRetry:
+			return fail.Wrap(fail.Cause(xerr), "stopping retries")
+		default:
+			return xerr
+		}
+	}
+
+	return nil
+}
+
+// rpcDeleteMetadataOfInstance changes the metadata associated with the instance
+func (s stack) rpcDeleteMetadataOfInstance(ctx context.Context, id string, tags map[string]string) fail.Error {
+	if id = strings.TrimSpace(id); id == "" {
+		return fail.InvalidParameterError("id", "cannot be empty string")
+	}
+
+	xerr := stacks.RetryableRemoteCall(ctx,
+		func() (innerErr error) {
+			for k := range tags {
+				res := servers.DeleteMetadatum(s.ComputeClient, id, k)
+				innerErr = res.ExtractErr()
+				return innerErr
+			}
+			return nil
+		},
+		NormalizeError,
+	)
+	if xerr != nil {
+		switch xerr.(type) {
+		case *fail.ErrTimeout:
+			return fail.Wrap(fail.Cause(xerr), "timeout")
+		case *retry.ErrStopRetry:
+			return fail.Wrap(fail.Cause(xerr), "stopping retries")
+		default:
+			return xerr
+		}
+	}
+
+	return nil
+}
+
 // rpcListServers lists servers
 func (s stack) rpcListServers(ctx context.Context) ([]*servers.Server, fail.Error) {
 	var resp []*servers.Server
@@ -218,6 +306,7 @@ func (s stack) rpcCreateServer(ctx context.Context, name string, networks []serv
 	if xerr != nil {
 		return &servers.Server{}, xerr
 	}
+
 	return server, nil
 }
 
@@ -313,7 +402,7 @@ func (s stack) rpcChangePortSecurity(ctx context.Context, portID string, state b
 
 			innerErr := ports.Update(s.NetworkClient, portID, updateOpts).ExtractInto(&portWithPortSecurityExtensions)
 			if innerErr != nil {
-				logrus.Warningf(innerErr.Error())
+				logrus.WithContext(ctx).Warningf(innerErr.Error())
 				return innerErr
 			}
 
@@ -350,7 +439,7 @@ func (s stack) rpcRemoveSGFromPort(ctx context.Context, portID string) (_ *ports
 
 			innerErr := ports.Update(s.NetworkClient, portID, updateOpts).ExtractInto(&portWithPortSecurityExtensions)
 			if innerErr != nil {
-				logrus.Warningf(innerErr.Error())
+				logrus.WithContext(ctx).Warningf(innerErr.Error())
 				return innerErr
 			}
 

--- a/lib/backend/iaas/stacks/openstack/stack.go
+++ b/lib/backend/iaas/stacks/openstack/stack.go
@@ -17,6 +17,7 @@
 package openstack // Package openstack contains the implemenation of a stack for OpenStack providers
 
 import (
+	context2 "context"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -272,4 +273,27 @@ func (s *stack) Timings() (temporal.Timings, fail.Error) {
 		s.MutableTimings = temporal.NewTimings()
 	}
 	return s.MutableTimings, nil
+}
+
+func (s *stack) UpdateTags(ctx context2.Context, kind abstract.Enum, id string, lmap map[string]string) fail.Error {
+	if kind != abstract.HostResource {
+		return fail.NotImplementedError("Tagging resources other than hosts not implemented yet")
+	}
+
+	xerr := s.rpcSetMetadataOfInstance(ctx, id, lmap)
+	return xerr
+}
+
+func (s *stack) DeleteTags(ctx context2.Context, kind abstract.Enum, id string, keys []string) fail.Error {
+	if kind != abstract.HostResource {
+		return fail.NotImplementedError("Tagging resources other than hosts not implemented yet")
+	}
+
+	report := make(map[string]string)
+	for _, k := range keys {
+		report[k] = ""
+	}
+
+	xerr := s.rpcDeleteMetadataOfInstance(ctx, id, report)
+	return xerr
 }

--- a/lib/backend/iaas/stacks/outscale/compute.go
+++ b/lib/backend/iaas/stacks/outscale/compute.go
@@ -634,50 +634,6 @@ func (s stack) addGPUs(ctx context.Context, request *abstract.HostRequest, tpl a
 	return createErr
 }
 
-// FIMXE Unused
-func (s stack) addVolume(ctx context.Context, request *abstract.HostRequest, vmID string) (ferr fail.Error) {
-	if request.DiskSize == 0 {
-		return nil
-	}
-
-	v, xerr := s.CreateVolume(ctx, abstract.VolumeRequest{
-		Name:  fmt.Sprintf("vol-%s", request.HostName),
-		Size:  request.DiskSize,
-		Speed: s.Options.Compute.DefaultVolumeSpeed,
-	})
-	if xerr != nil {
-		return xerr
-	}
-	defer func() {
-		ferr = debug.InjectPlannedFail(ferr)
-		if ferr != nil {
-			derr := s.DeleteVolume(context.Background(), v.ID)
-			if derr != nil {
-				_ = ferr.AddConsequence(derr)
-			}
-		}
-	}()
-
-	_, xerr = s.rpcCreateTags(ctx,
-		v.ID, map[string]string{
-			"DeleteWithVM":     "true",
-			"name":             fmt.Sprintf("vol-%s", request.HostName),
-			"ManagedBy":        "safescale",
-			"DeclaredInBucket": s.configurationOptions.MetadataBucket,
-			"CreationDate":     time.Now().Format(time.RFC3339),
-		},
-	)
-	if xerr != nil {
-		return xerr
-	}
-
-	_, xerr = s.CreateVolumeAttachment(ctx, abstract.VolumeAttachmentRequest{
-		HostID:   vmID,
-		VolumeID: v.ID,
-	})
-	return xerr
-}
-
 func (s stack) addPublicIP(ctx context.Context, nic osc.Nic) (_ osc.PublicIp, ferr fail.Error) {
 	// Allocate public IP
 	resp, xerr := s.rpcCreatePublicIP(ctx)

--- a/lib/backend/iaas/stacks/outscale/stack.go
+++ b/lib/backend/iaas/stacks/outscale/stack.go
@@ -280,3 +280,34 @@ func (s *stack) Timings() (temporal.Timings, fail.Error) {
 	}
 	return s.MutableTimings, nil
 }
+
+func (s *stack) UpdateTags(ctx context.Context, kind abstract.Enum, id string, lmap map[string]string) fail.Error {
+	if s == nil {
+		return fail.InvalidInstanceError()
+	}
+
+	if kind != abstract.HostResource {
+		return fail.NotImplementedError("Tagging resources other than hosts not implemented yet")
+	}
+
+	_, xerr := s.rpcCreateTags(ctx, id, lmap)
+	return xerr
+}
+
+func (s *stack) DeleteTags(ctx context.Context, kind abstract.Enum, id string, keys []string) fail.Error {
+	if s == nil {
+		return fail.InvalidInstanceError()
+	}
+
+	if kind != abstract.HostResource {
+		return fail.NotImplementedError("Tagging resources other than hosts not implemented yet")
+	}
+
+	report := make(map[string]string)
+	for _, k := range keys {
+		report[k] = ""
+	}
+
+	xerr := s.rpcDeleteTags(ctx, id, report)
+	return xerr
+}

--- a/lib/backend/resources/Makefile
+++ b/lib/backend/resources/Makefile
@@ -9,6 +9,7 @@ all: generate
 generate:
 	@(mkdir -p ./mocks) || true
 	@(cd enums && $(MAKE) $(@))
+	@(cd abstract && $(MAKE) $(@))
 	@(cd operations && $(MAKE) $(@))
 
 vet:

--- a/lib/backend/resources/abstract/Makefile
+++ b/lib/backend/resources/abstract/Makefile
@@ -1,0 +1,16 @@
+GO?=go
+
+.PHONY:	generate clean vet 
+
+all:	generate 
+
+vet:
+	@($(GO) vet ./...)
+
+DIRECTORIES := $(sort $(dir $(wildcard */)))
+
+generate:
+	@$(GO) generate -run stringer ./...
+
+clean:
+	@(for d in $(DIRECTORIES); do (cd $$d; $(RM) *_string.go || true); done)

--- a/lib/backend/resources/abstract/enum.go
+++ b/lib/backend/resources/abstract/enum.go
@@ -1,0 +1,18 @@
+package abstract
+
+//go:generate stringer -type=Enum
+
+// Enum ...
+type Enum int
+
+const (
+	UnknownResource Enum = iota
+	ClusterResource
+	HostResource
+	LabelResource
+	NetworkResource
+	ObjectStorageBucketResource
+	SecurityGroupResource
+	SubnetResource
+	VolumeResource
+)

--- a/lib/backend/resources/operations/clustertasks.go
+++ b/lib/backend/resources/operations/clustertasks.go
@@ -279,7 +279,7 @@ func (instance *Cluster) taskCreateCluster(task concurrency.Task, params concurr
 						_ = ferr.AddConsequence(tgerr)
 					}
 				} else {
-					logrus.Warningf("relying on metadata here was a mistake...")
+					logrus.WithContext(ctx).Warningf("relying on metadata here was a mistake...")
 				}
 			}
 		}()

--- a/lib/backend/resources/operations/securitygroupunsafe.go
+++ b/lib/backend/resources/operations/securitygroupunsafe.go
@@ -532,7 +532,7 @@ func (instance *SecurityGroup) unsafeBindToHost(inctx context.Context, hostInsta
 		}
 
 		hn := hostInstance.GetName()
-		logrus.Warningf("Binding security group %s to host %s", sgid, hn)
+		logrus.WithContext(ctx).Warningf("Binding security group %s to host %s", sgid, hn)
 
 		xerr := instance.Alter(ctx, func(clonable data.Clonable, props *serialize.JSONProperties) fail.Error {
 			if mark == resources.MarkSecurityGroupAsDefault {

--- a/lib/backend/resources/operations/servicetest_test.go
+++ b/lib/backend/resources/operations/servicetest_test.go
@@ -2797,16 +2797,22 @@ func (e *ServiceTest) DeleteVolumeAttachment(ctx context.Context, serverID, id s
 	e._survey("ServiceTest::DeleteVolumeAttachment (not implemented)")
 	return nil
 }
-func (e *ServiceTest) Migrate(ctx context.Context, operation string, params map[string]interface{}) fail.Error {
-	e._log("ServiceTest::Migrate (not implemented)")
-	return nil
-}
 func (e *ServiceTest) Timings() (temporal.Timings, fail.Error) {
 	if e.options.timingsErr != nil {
 		e._warnf("ServiceTest::Timings forced error \"%s\"\n", e.options.timingsErr.Error())
 		return nil, e.options.timingsErr
 	}
 	return e.options.timings, nil
+}
+
+func (e *ServiceTest) UpdateTags(ctx context.Context, kind abstract.Enum, id string, lmap map[string]string) fail.Error {
+	e._survey("ServiceTest::UpdateTags (not implemented)")
+	return nil
+}
+
+func (e *ServiceTest) DeleteTags(ctx context.Context, kind abstract.Enum, id string, keys []string) fail.Error {
+	e._survey("ServiceTest::DeleteTags (not implemented)")
+	return nil
 }
 
 // providers.Provider


### PR DESCRIPTION
Until now, tags and labels existed only in a configuration file and were not visible from other tools (like web consoles, clis, etc)

This PR introduces partial tagging support for each provider, so other tools other than SafeScale can read tags/labels associated to VMs